### PR TITLE
fix sorted current corporations

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -508,7 +508,7 @@ class User < ActiveRecord::Base
   def sorted_current_corporations
     cached do
       current_corporations.sort_by do |corporation|
-        corporation.membership_of(self).valid_from || corporation.membership_of(self).created_at
+        corporation.membership_of(self).valid_from || Time.zone.now - 100.years
       end
     end
   end


### PR DESCRIPTION
user_spec geht im Moment schief für #last_group_in_first_corporation
Das wird dadurch gelöst, dass die erste Korporation richtig berechnet wird. Bisher wurde die Korporation die erste, die eine UserGroupMembership ohne valid_from, aber mit einem frühen created_date hatte. 
Durch den Fix stellen solche Kanten keine Diskrimierung mehr dar.