### PR TITLE
Group mails: sender filter (2015-Roe2goh4)

### DIFF
--- a/app/assets/javascripts/your_platform/post.js.coffee
+++ b/app/assets/javascripts/your_platform/post.js.coffee
@@ -1,0 +1,9 @@
+reload_delivery_status = ->
+  if $('#post-deliveries').size() > 0
+    Turbolinks.visit(window.location.pathname, { change: ['post-deliveries'] })
+    setTimeout reload_delivery_status, 10000
+
+$(document).ready ->
+  if $('#post-deliveries').size() > 0
+    setTimeout reload_delivery_status, 5000
+

--- a/app/assets/javascripts/your_platform/posts.js.coffee
+++ b/app/assets/javascripts/your_platform/posts.js.coffee
@@ -62,6 +62,7 @@ ready = ->
       success: (r)->
         if real_message
           $('p.buttons.right').text(I18n.t( 'message_has_been_sent_to_n_recipients', {n: r.recipients_count}))
+          Turbolinks.visit r.post_url
     )
     click_event.preventDefault()
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -214,6 +214,7 @@ class GroupsController < ApplicationController
     permitted_keys += [:internal_token] if can? :change_internal_token, @group
     permitted_keys += [:direct_members_titles_string] if can? :update_memberships, @group
     permitted_keys += [:body] if can? :update, @group
+    permitted_keys += [:mailing_list_sender_filter] if can? :update, @group
     params.require(:group).permit(*permitted_keys)
   end
   

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -111,7 +111,7 @@ class GroupsController < ApplicationController
         # Everything else, we encode as UTF-8.
         #
         csv_data = @list_export.to_csv
-        if list_preset.include? 'dpag_internetmarke'
+        if list_preset.try(:include?, 'dpag_internetmarke')
           csv_data = csv_data.encode('ISO-8859-1')
         else
           # See: http://railscasts.com/episodes/362-exporting-csv-and-excel

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -89,7 +89,7 @@ class PostsController < ApplicationController
     if params[:notification] == "instantly"
       @send_counter = @post.send_as_email_to_recipients @recipients
       Notification.create_from_post(@post, sent_at: Time.zone.now) unless params[:recipient] == 'me'
-      flash[:notice] = "Nachricht wurde an #{@send_counter} Empfänger versandt."
+      flash[:notice] = "Nachricht wird an #{@send_counter} Empfänger versandt."
     else
       Notification.create_from_post(@post) unless params[:recipient] == 'me'
       flash[:notice] = "Nachricht wurde gespeichert. #{@recipients.count} Empfänger werden gemäß ihrer eigenen Benachrichtigungs-Einstellungen informiert, spätestens jedoch nach einem Tag."
@@ -101,7 +101,7 @@ class PostsController < ApplicationController
       format.html do
         redirect_to group_posts_path(@group), change: 'posts'
       end
-      format.json { render json: {recipients_count: @send_counter} }
+      format.json { render json: {recipients_count: @send_counter, post_url: @post.url} }
     end
     
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -135,7 +135,23 @@ class PostsController < ApplicationController
   # https://github.com/ivaldi/brimir
   #
   def create_via_email
-    authorize! :create, :post_via_email
+    #
+    # ## Authorization
+    # 
+    # In case of comments, the user is authenticated by his user token that is included in the
+    # reply-to email address, e.g. user-aeng9iLe...oi2iSh7Hahr.post-345.create-comment.plattform@example.com.
+    # We do not check authorization for comments at the moment. TODO
+    #
+    # In case of posts, the user is authenticated by the sender email address.
+    # TODO: Support uploading public keys to protect from forged email addresses.
+    # The authorization is done in the StoreMailAsPostsAndSendGroupMailJob.
+    # Rejection messages are also sent in the StoreMailAsPostsAndSendGroupMailJob.
+    #
+    # The following authorization step generally checks whether the platform mailgate
+    # should be used. This way, the mailgate can be switched off in the Ability class.
+    #
+    authorize! :use, :platform_mailgate
+    
     if params[:message]
       if ReceivedMail.new(params[:message]).recipient_email.include?('.create-comment.plattform@')
         # Then this responds to a conversation and should not create a new post but a comment instead.

--- a/app/jobs/store_mail_as_posts_and_send_group_mail_job.rb
+++ b/app/jobs/store_mail_as_posts_and_send_group_mail_job.rb
@@ -22,7 +22,7 @@ class StoreMailAsPostsAndSendGroupMailJob < ActiveJob::Base
       @posts = received_post_mail.store_as_posts_when_authorized
       received_post_mail.deliver_rejection_emails
     end
-    @posts.each { |post| post.send_as_email_to_recipients }  # TODO: post deliveries table to avoid timeout and generate delivery reports.
+    @posts.each { |post| post.send_as_email_to_recipients }
   end
   
   # We have to lock post mail processing in a way that does not allow

--- a/app/jobs/store_mail_as_posts_and_send_group_mail_job.rb
+++ b/app/jobs/store_mail_as_posts_and_send_group_mail_job.rb
@@ -20,7 +20,7 @@ class StoreMailAsPostsAndSendGroupMailJob < ActiveJob::Base
     lock do
       received_post_mail = ReceivedPostMail.new(message)
       @posts = received_post_mail.store_as_posts_when_authorized
-      # received_post_mail.deliver_rejection_emails  # TODO
+      received_post_mail.deliver_rejection_emails
     end
     @posts.each { |post| post.send_as_email_to_recipients }  # TODO: post deliveries table to avoid timeout and generate delivery reports.
   end

--- a/app/jobs/store_mail_as_posts_and_send_group_mail_job.rb
+++ b/app/jobs/store_mail_as_posts_and_send_group_mail_job.rb
@@ -19,9 +19,10 @@ class StoreMailAsPostsAndSendGroupMailJob < ActiveJob::Base
     wait_for_unlock
     lock do
       received_post_mail = ReceivedPostMail.new(message)
-      @posts = received_post_mail.store_as_posts
+      @posts = received_post_mail.store_as_posts_when_authorized
+      # received_post_mail.deliver_rejection_emails  # TODO
     end
-    @posts.each { |post| post.send_as_email_to_recipients }
+    @posts.each { |post| post.send_as_email_to_recipients }  # TODO: post deliveries table to avoid timeout and generate delivery reports.
   end
   
   # We have to lock post mail processing in a way that does not allow

--- a/app/mailers/base_mailer.rb
+++ b/app/mailers/base_mailer.rb
@@ -3,6 +3,9 @@ class BaseMailer < ActionMailer::Base
   helper MarkupHelper
   helper IconHelper
   helper MarkdownHelper
+  helper MentionsHelper
+  helper QuickLinkHelper
+  helper EmojiHelper
   
   helper ApplicationHelper
   default from: 'wingolfsplattform@wingolf.org'

--- a/app/mailers/post_rejection_mailer.rb
+++ b/app/mailers/post_rejection_mailer.rb
@@ -1,0 +1,11 @@
+class PostRejectionMailer < BaseMailer
+  default from: 'no-reply@your-platform.org'
+  
+  def post_rejection_email(sender_email, recipient_name, subject, reason)
+    @recipient_name = recipient_name
+    @subject = subject
+    @reason = reason
+    
+    mail to: sender_email, subject: @subject
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -415,7 +415,12 @@ class Ability
     can [:create_post, :create_post_for, :create_post_via_email, :force_post_notification], Group do |group|
       group.user_matches_mailing_list_sender_filter?(user)
     end
-      
+    
+    # Activate platform mailgate, i.e. accept incoming email.
+    # The authorization to send to a specific group is done separately in
+    # the StoreMailAsPostsAndSendGroupMailJob.
+    #
+    can :use, :platform_mailgate
     
     # All users can use the blue help button.
     #

--- a/app/models/concerns/group_mailing_lists.rb
+++ b/app/models/concerns/group_mailing_lists.rb
@@ -10,4 +10,48 @@ concern :GroupMailingLists do
   def mailing_lists
     self.profile_fields.where(type: 'ProfileFieldTypes::MailingListEmail')
   end
+  
+  # Possible settings for the sender filter, i.e. the group attribute that determines
+  # whether an incoming post is accepted or rejected.
+  #
+  def mailing_list_sender_filter_settings
+    %w(open users_with_account corporation_members group_members officers group_officers global_officers)
+  end
+  
+  # Checks whether the given user is allowed to send an email to the mailing lists 
+  # of this group.
+  #
+  def user_matches_mailing_list_sender_filter?(user)
+    case self.mailing_list_sender_filter.to_s
+    when 'open'
+      true
+    when 'users_with_account'
+      user && user.has_account?
+    when 'corporation_members'
+      user && user.member_of?(self.corporation)
+    when 'group_members'
+      user && user.member_of?(self)
+    when 'officers'
+      user && user.officer_of_anything?
+    when 'group_officers'
+      user && user.in?(self.officers)
+    when 'global_officers'
+      user && user.global_officer?
+    when '', nil  # (default setting)
+      if self.kind_of? OfficerGroup
+        # Everyone can contact officers.
+        true
+      elsif self.corporation.present?
+        # If the group has an associated corporation, all members
+        # of the corporation can post.
+        user && user.member_of?(self.corporation)
+      else
+        # If this is a regular group, all group members can post.
+        user && user.member_of?(self)
+      end
+    else
+      false
+    end
+  end
+  
 end

--- a/app/models/concerns/group_mailing_lists.rb
+++ b/app/models/concerns/group_mailing_lists.rb
@@ -1,0 +1,13 @@
+concern :GroupMailingLists do
+  
+  included do
+    attr_accessible :mailing_list_sender_filter
+  end
+  
+  # Returns all mailing list profile fields, i.e. email addresses that
+  # are used as mailing list for that group.
+  #
+  def mailing_lists
+    self.profile_fields.where(type: 'ProfileFieldTypes::MailingListEmail')
+  end
+end

--- a/app/models/concerns/user_roles.rb
+++ b/app/models/concerns/user_roles.rb
@@ -172,10 +172,22 @@ concern :UserRoles do
       UserGroupMembership.find_by_user_and_group(self, Group.everyone.admins_parent).try(:destroy)
     end
   end
+  
+
+  # Officers
+  # ==========================================================================================
+  
+  def officer_of_anything?
+    self.groups.detect { |g| g.type == 'OfficerGroup' } || false
+  end
 
 
   # Methods transferred from former Role class
   # ==========================================================================================
+
+  def global_officer?
+    is_global_officer?
+  end
 
   def is_global_officer?
     cached { global_admin? || ancestor_groups.flagged(:global_officer).exists? }

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -39,8 +39,8 @@ class Group < ActiveRecord::Base
   include GroupMixins::HiddenUsers
   include GroupMixins::Developers
   include GroupMixins::Officers
-
   include GroupMixins::Import
+  include GroupMailingLists
 
   after_create     :import_default_group_structure  # from GroupMixins::Import
   after_save       { self.delay.delete_cache }

--- a/app/models/post_delivery.rb
+++ b/app/models/post_delivery.rb
@@ -1,0 +1,55 @@
+class PostDelivery < ActiveRecord::Base
+  
+  belongs_to :post
+  belongs_to :user
+  
+  scope :sent, -> { where.not(sent_at: nil) }
+  scope :failed, -> { where.not(failed_at: nil) }
+  scope :due, -> { where(sent_at: nil, failed_at: nil) }
+  
+  def deliver
+    if not user.has_account?
+      self.comment = "User has no account."
+      self.failed_at = Time.zone.now
+      self.save
+      return false
+    end
+    
+    if user.email_does_not_work?
+      self.comment = "Email does not work."
+      self.user_email = user.email
+      self.failed_at = Time.zone.now
+      self.save
+      return false
+    end
+    
+    if user.has_account? and not user.email_does_not_work?
+      self.user_email = user.email
+      
+      Rails.logger.info "Sending post as email to #{user.inspect} (#{user_email}) ..."
+      if PostMailer.post_email(post.text, [user], post.email_subject, post.author, post.group, post).deliver_now
+        self.sent_at = Time.zone.now
+        self.save
+        return self
+      else
+        self.comment = "Delivery failed."
+        self.failed_at = Time.zone.now
+        self.save
+        return false
+      end
+    end
+  end
+  
+  def deliver_if_due
+    deliver if due?
+  end
+  
+  def due?
+    self.class.due.exists?(self.id)
+  end
+  
+  def self.deliver_if_due(id)
+    PostDelivery.find(id).deliver_if_due
+  end
+  
+end

--- a/app/models/received_mail.rb
+++ b/app/models/received_mail.rb
@@ -121,6 +121,11 @@ class ReceivedMail
       recipient_group_by_email(email)
     end.uniq - [nil]
   end
+  def unmatched_recipient_emails
+    recipient_emails.select do |email|
+      recipient_by_email(email).nil?
+    end - [nil]
+  end
   
   def message_id
     @email.message_id

--- a/app/models/received_post_mail.rb
+++ b/app/models/received_post_mail.rb
@@ -89,10 +89,10 @@ class ReceivedPostMail < ReceivedMail
   
   def deliver_rejection_emails
     @unauthorized_groups && @unauthorized_groups.each do |group|
-      PostRejectionMailer.post_rejection_email(self.sender_email, group.name, "Re: #{self.subject}", "You are not authorized to send messages to this group.").deliver_later
+      PostRejectionMailer.post_rejection_email(self.sender_email, group.name, "Re: #{self.subject}", "You are not authorized to send messages to this group.").deliver_now
     end
     self.unmatched_recipient_emails.each do |email|
-      PostRejectionMailer.post_rejection_email(self.sender_email, email, "Re: #{self.subject}", "Recipient could not be determined. Maybe a typo in the email address?").deliver_later
+      PostRejectionMailer.post_rejection_email(self.sender_email, email, "Re: #{self.subject}", "Recipient could not be determined. Maybe a typo in the email address?").deliver_now
     end
   end
 

--- a/app/models/received_post_mail.rb
+++ b/app/models/received_post_mail.rb
@@ -26,49 +26,60 @@ class ReceivedPostMail < ReceivedMail
   end
   
   def store_as_posts
+    store_as_posts_when_authorized
+  end
+  
+  def store_as_posts_when_authorized
     recipient_groups.collect do |group|
       if no_duplicates_exist?(group) || Rails.env.development?
-        post = Post.new
-        if self.sender_by_email
-          post.author_user_id = self.sender_user.id
-        elsif self.sender_by_name
-          post.author_user_id = self.sender_user.id
-          post.external_author = self.sender_string
-        else
-          post.external_author = self.sender_string
-        end
-        raise 'something is wrong. this group is not a recipient' unless group.in?(self.recipient_groups)
-        post.group_id = group.id
-        post.sent_at = Time.zone.now
-        post.subject = self.subject
-        post.text = self.content
-        post.content_type = self.content_type
-        post.message_id = self.message_id
-        post.save
-        if self.has_attachments?
-
-          # I've copied this from https://github.com/ivaldi/brimir: ticket_mailer.rb
-          self.attachments.each do |attachment|
-            file = StringIO.new(attachment.decoded)
-            # add needed fields for paperclip
-            file.class.class_eval { attr_accessor :original_filename, :content_type }
-            file.original_filename = attachment.filename
-            file.content_type = attachment.mime_type 
-            post_attachment = post.attachments.create(file: file)
-            post_attachment.save # FIXME do we need this because of paperclip?
+        if Ability.new(self.sender_user).can? :create_post_for, group
+          post = Post.new
+          if self.sender_by_email
+            post.author_user_id = self.sender_user.id
+          elsif self.sender_by_name
+            post.author_user_id = self.sender_user.id
+            post.external_author = self.sender_string
+          else
+            post.external_author = self.sender_string
           end
-
-          # We need to replace the inline-image sources in the message text:
-          attachment_counter = 0
-          post.text = post.text.gsub(/(<img [^>]* src=)("cid:[^>"]*")([^>]*>)/) do
-            attachment_counter += 1
-            attachment = post.attachments.find_by_type("image")[attachment_counter - 1]
-            image_url = Rails.application.routes.url_helpers.root_url(Rails.application.config.action_mailer.default_url_options) + attachment.file.url
-            "#{$1}\"#{image_url}\"#{$3}" # "<img src=...>" from regex
-          end
+          raise 'something is wrong. this group is not a recipient' unless group.in?(self.recipient_groups)
+          post.group_id = group.id
+          post.sent_at = Time.zone.now
+          post.subject = self.subject
+          post.text = self.content
+          post.content_type = self.content_type
+          post.message_id = self.message_id
           post.save
+          if self.has_attachments?
+          
+            # I've copied this from https://github.com/ivaldi/brimir: ticket_mailer.rb
+            self.attachments.each do |attachment|
+              file = StringIO.new(attachment.decoded)
+              # add needed fields for paperclip
+              file.class.class_eval { attr_accessor :original_filename, :content_type }
+              file.original_filename = attachment.filename
+              file.content_type = attachment.mime_type 
+              post_attachment = post.attachments.create(file: file)
+              post_attachment.save # FIXME do we need this because of paperclip?
+            end
+          
+            # We need to replace the inline-image sources in the message text:
+            attachment_counter = 0
+            post.text = post.text.gsub(/(<img [^>]* src=)("cid:[^>"]*")([^>]*>)/) do
+              attachment_counter += 1
+              attachment = post.attachments.find_by_type("image")[attachment_counter - 1]
+              image_url = Rails.application.routes.url_helpers.root_url(Rails.application.config.action_mailer.default_url_options) + attachment.file.url
+              "#{$1}\"#{image_url}\"#{$3}" # "<img src=...>" from regex
+            end
+            post.save
+          end
+          post
+        else # unauthorized!
+          @unauthorized_groups ||= []
+          @unauthorized_groups << group
+          Rails.logger.warn "#{self.sender_email} is not authorized to create a post in group #{group.id} (#{group.name}). Did not save message #{self.message_id} as post."
+          nil
         end
-        post
       else # duplicates exist!
         Rails.logger.warn "Email duplicate found for message #{self.message_id}. Did not save as post!"
         nil

--- a/app/models/received_post_mail.rb
+++ b/app/models/received_post_mail.rb
@@ -86,5 +86,14 @@ class ReceivedPostMail < ReceivedMail
       end
     end - [nil]
   end
+  
+  def deliver_rejection_emails
+    @unauthorized_groups && @unauthorized_groups.each do |group|
+      PostRejectionMailer.post_rejection_email(self.sender_email, group.name, "Re: #{self.subject}", "You are not authorized to send messages to this group.").deliver_later
+    end
+    self.unmatched_recipient_emails.each do |email|
+      PostRejectionMailer.post_rejection_email(self.sender_email, email, "Re: #{self.subject}", "Recipient could not be determined. Maybe a typo in the email address?").deliver_later
+    end
+  end
 
 end

--- a/app/views/mailing_lists/index.html.haml
+++ b/app/views/mailing_lists/index.html.haml
@@ -18,6 +18,14 @@
                                    :profile_field => {:type => 'ProfileFieldTypes::MailingListEmail', :label => t(:mailing_list)},
                                    :section => 'mailing_list_adresses'), :method => 'post')
 
+%h1.sender_filter= t :mailing_list_sender_filter
+%div.section.sender_filter
+  %p
+    %strong Absender-Filter:
+    = best_in_place @group, :mailing_list_sender_filter, as: :select, collection: Hash[@group.mailing_list_sender_filter_settings.collect { |setting| [setting, I18n.t("sender_filter.#{setting}")] }]
+  %p Es werden nur Nachrichten von diesen Absendern zugelassen. Alle übrigen Nachrichten werden abgewiesen.
+  
+
 %h1 E-Mail-Verteiler einrichten
 %div
   %p 

--- a/app/views/post_rejection_mailer/post_rejection_email.text.erb
+++ b/app/views/post_rejection_mailer/post_rejection_email.text.erb
@@ -1,0 +1,11 @@
+Your email message
+
+    <%= @subject %>
+    
+to
+
+    <%= @recipient_name %>
+
+has been rejected.
+
+Reason: <%= @reason || "You are not authorized to send messages to this group." %>

--- a/app/views/posts/_new.html.haml
+++ b/app/views/posts/_new.html.haml
@@ -1,32 +1,33 @@
-%h1= "#{t(:new_post_to)} #{@group.name}"
-%div.new_post.post
-  = form_for(@new_post, turboboost: true, html: {multipart: true}) do |form|
-    = form.hidden_field :group_id
-    = form.hidden_field :author_user_id
-    .media
-      .media-left.new_post_avatar= user_avatar(current_user)
-      .media-body
-        .preview
-          .post-header= t(:preview_post)
-          .post-body
-        = form.text_area :text, placeholder: t(:enter_new_post_here), class: 'form-control', data: {user_titles_path: autocomplete_title_users_path}
-        .post_tools
-          .post_attachment
-            = form.fields_for :attachments, Attachment.new do |builder|
-              %fieldset
-                = builder.file_field :file
-          .what_will_happen
-            - if can? :force_post_notification, @group
-              %select.notification{name: 'notification'}
-                %option{value: ''}= t(:notify_according_to_notification_settings)
-                %option{value: 'instantly'}= t(:notify_all_immideately)
-            - else
-              Beim Klick auf "Abschicken" wird die Nachricht gespeichert. Die Mitglieder der Gruppe
-              = link_to @group.name, @group
-              werden gemäß ihrer eigenen Benachrichtigungs-Einstellungen per E-Mail informiert,
-              spätestens jedoch nach einem Tag.
-
-          = form.submit t(:submit_post), class: 'submit_post btn btn-primary right'
-          = link_to t(:preview_post), post_preview_path, class: 'preview_post btn btn-default right'
-          %span.right
+- if can? :create_post_for, @group
+  %h1= "#{t(:new_post_to)} #{@group.name}"
+  %div.new_post.post
+    = form_for(@new_post, turboboost: true, html: {multipart: true}) do |form|
+      = form.hidden_field :group_id
+      = form.hidden_field :author_user_id
+      .media
+        .media-left.new_post_avatar= user_avatar(current_user)
+        .media-body
+          .preview
+            .post-header= t(:preview_post)
+            .post-body
+          = form.text_area :text, placeholder: t(:enter_new_post_here), class: 'form-control', data: {user_titles_path: autocomplete_title_users_path}
+          .post_tools
+            .post_attachment
+              = form.fields_for :attachments, Attachment.new do |builder|
+                %fieldset
+                  = builder.file_field :file
+            .what_will_happen
+              - if can? :force_post_notification, @group
+                %select.notification{name: 'notification'}
+                  %option{value: ''}= t(:notify_according_to_notification_settings)
+                  %option{value: 'instantly'}= t(:notify_all_immideately)
+              - else
+                Beim Klick auf "Abschicken" wird die Nachricht gespeichert. Die Mitglieder der Gruppe
+                = link_to @group.name, @group
+                werden gemäß ihrer eigenen Benachrichtigungs-Einstellungen per E-Mail informiert,
+                spätestens jedoch nach einem Tag.
+  
+            = form.submit t(:submit_post), class: 'submit_post btn btn-primary right'
+            = link_to t(:preview_post), post_preview_path, class: 'preview_post btn btn-default right'
+            %span.right
             

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -1,5 +1,5 @@
 %h1.post.post-subject
-  - if post == @navable
+  - if @post and not @posts
     = post.subject
   - else
     = link_to post.subject, post
@@ -24,6 +24,10 @@
               = link_to post.group.title, post.group
         %div.post-date
           = localize(post.sent_at) if post.sent_at
+        - if @post and not @posts
+          %div.post-deliveries#post-deliveries
+            =t :post_sent_to_n_recipients, n: post.deliveries.sent.map(&:user_id).uniq.count if post.deliveries.sent.count > 0
+            =t :post_failed_to_send_to_n_recipients, n: post.deliveries.failed.map(&:user_id).uniq.count if post.deliveries.failed.count > 0
           
       %div.post-body
         = markup post.text.html_safe

--- a/config/locales/mailing_lists/de.yml
+++ b/config/locales/mailing_lists/de.yml
@@ -8,3 +8,13 @@ de:
   no_need_to_manage_list_members_separately: "Hierbei wird immer das aktuelle Mitglieder-Verzeichnis der Plattform verwendet, sodass die Adressaten der E-Mail-Verteiler nicht separat gepflegt werden müssen."
   
   mailing_list_adresses: Verteiler-Adressen
+  
+  mailing_list_sender_filter: Absender-Filter für E-Mail-Verteiler
+  sender_filter:
+    open:                     Offen (Standard für Amtsträger-Gruppen)
+    users_with_account:       Benutzer mit Account
+    corporation_members:      Mitglieder der Korporation (Standard für Gruppen einer Korporation)
+    group_members:            Mitglieder der Gruppe (Standard für reguläre Gruppen)
+    group_officers:           Amtsträger der Gruppe
+    officers:                 Amtsträger
+    global_officers:          Bundesamtsträger

--- a/config/locales/mailing_lists/en.yml
+++ b/config/locales/mailing_lists/en.yml
@@ -1,0 +1,20 @@
+en:
+  mailing_list: Mailing list
+  mailing_lists: Mailing lists
+  manage_mailing_lists: Manage mailing lists
+  
+  what_are_mailing_lists: What are mailing lists?
+  mailing_lists_forward_emails_to_all_group_members: Mailing lists forward emails to mailing list addresses (e.g. mailing-list@example.com) to all group members.
+  no_need_to_manage_list_members_separately: The mailing lists use the current memberships stored in this application. There is no need to manage the mailing list memberships separately.
+
+  mailing_list_adresses: Mailing list addresses
+  
+  mailing_list_sender_filter: Sender filter for mailing lists
+  sender_filter:
+    open:                     Open (default for officer groups)
+    users_with_account:       Users with account
+    corporation_members:      Corporation memebrs (default for groups of a corporation)
+    group_members:            Group members (default for regular groups)
+    group_officers:           Group officers
+    officers:                 Officers
+    global_officers:          Global officers

--- a/config/locales/post_deliveries/de.yml
+++ b/config/locales/post_deliveries/de.yml
@@ -1,0 +1,3 @@
+de:
+  post_sent_to_n_recipients: "Erfolgreich an %{n} Empfänger gesendet."
+  post_failed_to_send_to_n_recipients: "Versand an %{n} Empfänger fehlgeschlagen."

--- a/config/locales/post_deliveries/en.yml
+++ b/config/locales/post_deliveries/en.yml
@@ -1,0 +1,3 @@
+en:
+  post_sent_to_n_recipients: "Successfully sent to %{n} recipients."
+  post_failed_to_send_to_n_recipients: "Failed to send to %{n} recipients."

--- a/db/migrate/20150928165027_add_sender_filter_to_groups.rb
+++ b/db/migrate/20150928165027_add_sender_filter_to_groups.rb
@@ -1,0 +1,5 @@
+class AddSenderFilterToGroups < ActiveRecord::Migration
+  def change
+    add_column :groups, :mailing_list_sender_filter, :string
+  end
+end

--- a/db/migrate/20150930184624_create_post_deliveries.rb
+++ b/db/migrate/20150930184624_create_post_deliveries.rb
@@ -1,0 +1,14 @@
+class CreatePostDeliveries < ActiveRecord::Migration
+  def change
+    create_table :post_deliveries do |t|
+      t.integer :post_id
+      t.integer :user_id
+      t.string :user_email
+      t.datetime :sent_at
+      t.datetime :failed_at
+      t.string :comment
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/demo_app/my_platform/db/migrate/20150928210248_add_sender_filter_to_groups.your_platform.rb
+++ b/demo_app/my_platform/db/migrate/20150928210248_add_sender_filter_to_groups.your_platform.rb
@@ -1,0 +1,6 @@
+# This migration comes from your_platform (originally 20150928165027)
+class AddSenderFilterToGroups < ActiveRecord::Migration
+  def change
+    add_column :groups, :mailing_list_sender_filter, :string
+  end
+end

--- a/demo_app/my_platform/db/migrate/20150930184703_create_post_deliveries.your_platform.rb
+++ b/demo_app/my_platform/db/migrate/20150930184703_create_post_deliveries.your_platform.rb
@@ -1,0 +1,15 @@
+# This migration comes from your_platform (originally 20150930184624)
+class CreatePostDeliveries < ActiveRecord::Migration
+  def change
+    create_table :post_deliveries do |t|
+      t.integer :post_id
+      t.integer :user_id
+      t.string :user_email
+      t.datetime :sent_at
+      t.datetime :failed_at
+      t.string :comment
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/demo_app/my_platform/db/schema.rb
+++ b/demo_app/my_platform/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150707223927) do
+ActiveRecord::Schema.define(version: 20150928210248) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -133,14 +133,15 @@ ActiveRecord::Schema.define(version: 20150707223927) do
   add_index "geo_locations", ["address"], name: "index_geo_locations_on_address", using: :btree
 
   create_table "groups", force: :cascade do |t|
-    t.string   "name",           limit: 255
+    t.string   "name",                       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "token",          limit: 255
-    t.string   "extensive_name", limit: 255
-    t.string   "internal_token", limit: 255
-    t.text     "body",           limit: 65535
-    t.string   "type",           limit: 255
+    t.string   "token",                      limit: 255
+    t.string   "extensive_name",             limit: 255
+    t.string   "internal_token",             limit: 255
+    t.text     "body",                       limit: 65535
+    t.string   "type",                       limit: 255
+    t.string   "mailing_list_sender_filter", limit: 255
   end
 
   create_table "issues", force: :cascade do |t|

--- a/demo_app/my_platform/db/schema.rb
+++ b/demo_app/my_platform/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150928210248) do
+ActiveRecord::Schema.define(version: 20150930184703) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -251,6 +251,17 @@ ActiveRecord::Schema.define(version: 20150928210248) do
   end
 
   add_index "pages", ["author_user_id"], name: "pages_author_user_id_fk", using: :btree
+
+  create_table "post_deliveries", force: :cascade do |t|
+    t.integer  "post_id",    limit: 4
+    t.integer  "user_id",    limit: 4
+    t.string   "user_email", limit: 255
+    t.datetime "sent_at"
+    t.datetime "failed_at"
+    t.string   "comment",    limit: 255
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+  end
 
   create_table "posts", force: :cascade do |t|
     t.string   "subject",         limit: 255

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -55,7 +55,6 @@ describe Ability do
       context "when the user is no member of a group" do
         before { @group = create(:group) }
         he { should_not be_able_to :index_posts, @group }
-        he { should_not be_able_to :create_post_for, @group }
         context "when there is a post in this group" do
           before do
             @post = @group.posts.create
@@ -83,7 +82,6 @@ describe Ability do
           Mention.create_multiple(create(:user), @comment, @comment.text)
         end
         specify { @group.members.should_not include user }
-        he { should_not be_able_to :create_post_for, @group }
         he { should be_able_to :read, @post }
         he { should be_able_to :read, @comment }
         he { should be_able_to :create_comment_for, @post }
@@ -98,7 +96,6 @@ describe Ability do
           Mention.create_multiple(create(:user), @post, @post.text)
         end
         specify { @group.members.should_not include user }
-        he { should_not be_able_to :create_post_for, @group }
         he { should be_able_to :read, @post }
         he { should be_able_to :create_comment_for, @post }
         he { should be_able_to :read, @post_attachment }

--- a/spec/models/ability_to_use_mailing_lists_spec.rb
+++ b/spec/models/ability_to_use_mailing_lists_spec.rb
@@ -1,0 +1,446 @@
+require 'spec_helper'
+require 'cancan/matchers'
+
+# In order to call the user "he" rather than "it", 
+# we have to define an alias here.
+# 
+# http://stackoverflow.com/questions/12317558/alias-it-in-rspec
+#
+RSpec.configure do |c|
+  c.alias_example_to :he
+end
+
+describe Ability do
+  
+  before { @group = create :group }
+  
+  describe "for users without account" do
+    let(:user) { nil }
+    let(:ability) { Ability.new(nil) }
+    subject { ability }
+    let(:the_user) { subject }
+    
+    describe "for regular @groups" do
+      describe "sender filter" do
+        describe '(empty)' do
+          before { @group.mailing_list_sender_filter = ""; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe '(nil)' do
+          before { @group.mailing_list_sender_filter = nil; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'open' do
+          before { @group.mailing_list_sender_filter = :open; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'users_with_account' do
+          before { @group.mailing_list_sender_filter = :users_with_account; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'corporation_members' do
+          before { @group.mailing_list_sender_filter = :corporation_members; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'group_members' do
+          before { @group.mailing_list_sender_filter = :group_members; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'officers' do
+          before { @group.mailing_list_sender_filter = :officers; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'group_officers' do
+          before { @group.mailing_list_sender_filter = :group_officers; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'global_officers' do
+          before { @group.mailing_list_sender_filter = :global_officers; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+      end
+    end
+    
+    describe "for the @group being an OfficerGroup" do
+      before { @group.type = "OfficerGroup"; @group.save; @group = Group.find(@group.id) }
+
+      describe "sender filter" do
+        describe '(empty)' do
+          before { @group.mailing_list_sender_filter = ""; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe '(nil)' do
+          before { @group.mailing_list_sender_filter = nil; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+      end
+    end
+    
+    describe "for the @group having a corporation" do
+      before do
+        @corporation = create :corporation_with_status_groups
+        @corporation << @group
+      end
+
+      describe "sender filter" do
+        describe '(empty)' do
+          before { @group.mailing_list_sender_filter = ""; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe '(nil)' do
+          before { @group.mailing_list_sender_filter = nil; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+      end
+    end
+  end
+  
+  
+  # I'm sorry. I do have problems with cancan's terminology, here.
+  # For me, the User can do something, i.e. I would ask 
+  #
+  #   @user.can? :manage, @page
+  #
+  # But for cancan, it's 
+  #
+  #   Ability.new(@user).can? :manage, @page
+  #
+  # That is why I let(:the_user) be the ability.
+  # Also note, "he" refers to the regular "it" call.
+  # I just like to call the user "he" rather than "it".
+  #
+  describe "for users with account" do
+    let(:user) { create(:user_with_account) }
+    let(:ability) { Ability.new(user) }
+    subject { ability }
+    let(:the_user) { subject }
+    
+    describe "without the user being any member" do
+      describe "for regular @groups" do
+        describe "sender filter" do
+          describe '(empty)' do
+            before { @group.mailing_list_sender_filter = ""; @group.save }
+            he { should_not be_able_to :create_post_for, @group }
+          end
+          describe '(nil)' do
+            before { @group.mailing_list_sender_filter = nil; @group.save }
+            he { should_not be_able_to :create_post_for, @group }
+          end
+          describe 'open' do
+            before { @group.mailing_list_sender_filter = :open; @group.save }
+            he { should be_able_to :create_post_for, @group }
+          end
+          describe 'users_with_account' do
+            before { @group.mailing_list_sender_filter = :users_with_account; @group.save }
+            he { should be_able_to :create_post_for, @group }
+          end
+          describe 'corporation_members' do
+            before { @group.mailing_list_sender_filter = :corporation_members; @group.save }
+            he { should_not be_able_to :create_post_for, @group }
+          end
+          describe 'group_members' do
+            before { @group.mailing_list_sender_filter = :group_members; @group.save }
+            he { should_not be_able_to :create_post_for, @group }
+          end
+          describe 'officers' do
+            before { @group.mailing_list_sender_filter = :officers; @group.save }
+            he { should_not be_able_to :create_post_for, @group }
+          end
+          describe 'group_officers' do
+            before { @group.mailing_list_sender_filter = :group_officers; @group.save }
+            he { should_not be_able_to :create_post_for, @group }
+          end
+          describe 'global_officers' do
+            before { @group.mailing_list_sender_filter = :global_officers; @group.save }
+            he { should_not be_able_to :create_post_for, @group }
+          end
+        end
+      end
+      
+      describe "for the @group being an OfficerGroup" do
+        before { @group.type = "OfficerGroup"; @group.save; @group = Group.find(@group.id) }
+      
+        describe "sender filter" do
+          describe '(empty)' do
+            before { @group.mailing_list_sender_filter = ""; @group.save }
+            he { should be_able_to :create_post_for, @group }
+          end
+          describe '(nil)' do
+            before { @group.mailing_list_sender_filter = nil; @group.save }
+            he { should be_able_to :create_post_for, @group }
+          end
+        end
+      end
+      
+      describe "for the @group having a corporation" do
+        before do
+          @corporation = create :corporation_with_status_groups
+          @corporation << @group
+        end
+      
+        describe "sender filter" do
+          describe '(empty)' do
+            before { @group.mailing_list_sender_filter = ""; @group.save }
+            he { should_not be_able_to :create_post_for, @group }
+          end
+          describe '(nil)' do
+            before { @group.mailing_list_sender_filter = nil; @group.save }
+            he { should_not be_able_to :create_post_for, @group }
+          end
+        end
+      end
+    end
+    
+    describe "for corporation members" do
+      before do
+        @corporation = create :corporation_with_status_groups
+        @corporation.status_groups.first.assign_user user
+        @corporation << @group
+      end
+      
+      describe "sender filter" do
+        describe '(empty)' do
+          before { @group.mailing_list_sender_filter = ""; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe '(nil)' do
+          before { @group.mailing_list_sender_filter = nil; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'open' do
+          before { @group.mailing_list_sender_filter = :open; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'users_with_account' do
+          before { @group.mailing_list_sender_filter = :users_with_account; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'corporation_members' do
+          before { @group.mailing_list_sender_filter = :corporation_members; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'group_members' do
+          before { @group.mailing_list_sender_filter = :group_members; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'officers' do
+          before { @group.mailing_list_sender_filter = :officers; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'group_officers' do
+          before { @group.mailing_list_sender_filter = :group_officers; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'global_officers' do
+          before { @group.mailing_list_sender_filter = :global_officers; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+      end
+      
+      describe "for the @group being an OfficerGroup" do
+        before { @group.type = "OfficerGroup"; @group.save; @group = Group.find(@group.id) }
+      
+        describe "sender filter" do
+          describe '(empty)' do
+            before { @group.mailing_list_sender_filter = ""; @group.save }
+            he { should be_able_to :create_post_for, @group }
+          end
+          describe '(nil)' do
+            before { @group.mailing_list_sender_filter = nil; @group.save }
+            he { should be_able_to :create_post_for, @group }
+          end
+        end
+      end
+    end
+
+    describe "for @group members" do
+      before { @group.assign_user user }
+      
+      describe "sender filter" do
+        describe '(empty)' do
+          before { @group.mailing_list_sender_filter = ""; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe '(nil)' do
+          before { @group.mailing_list_sender_filter = nil; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'open' do
+          before { @group.mailing_list_sender_filter = :open; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'users_with_account' do
+          before { @group.mailing_list_sender_filter = :users_with_account; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'corporation_members' do
+          before { @group.mailing_list_sender_filter = :corporation_members; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'group_members' do
+          before { @group.mailing_list_sender_filter = :group_members; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'officers' do
+          before { @group.mailing_list_sender_filter = :officers; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'group_officers' do
+          before { @group.mailing_list_sender_filter = :group_officers; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'global_officers' do
+          before { @group.mailing_list_sender_filter = :global_officers; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+      end
+    end
+
+    describe "for officers of the @group" do
+      before do
+        @corporation = create :corporation_with_status_groups
+        @corporation << @group
+        @officer_group = @group.create_officer_group name: 'President'
+        @officer_group.assign_user user
+      end
+      
+      describe "sender filter" do
+        describe '(empty)' do
+          before { @group.mailing_list_sender_filter = ""; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe '(nil)' do
+          before { @group.mailing_list_sender_filter = nil; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'open' do
+          before { @group.mailing_list_sender_filter = :open; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'users_with_account' do
+          before { @group.mailing_list_sender_filter = :users_with_account; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'corporation_members' do
+          before { @group.mailing_list_sender_filter = :corporation_members; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'group_members' do
+          before { @group.mailing_list_sender_filter = :group_members; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'officers' do
+          before { @group.mailing_list_sender_filter = :officers; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'group_officers' do
+          before { @group.mailing_list_sender_filter = :group_officers; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'global_officers' do
+          before { @group.mailing_list_sender_filter = :global_officers; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+      end
+    end
+
+    describe "for officers of another @group" do
+      before do
+        @other_group = create :group
+        @officer_group = @other_group.create_officer_group name: 'President'
+        @officer_group.assign_user user
+      end
+      
+      describe "sender filter" do
+        describe '(empty)' do
+          before { @group.mailing_list_sender_filter = ""; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe '(nil)' do
+          before { @group.mailing_list_sender_filter = nil; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'open' do
+          before { @group.mailing_list_sender_filter = :open; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'users_with_account' do
+          before { @group.mailing_list_sender_filter = :users_with_account; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'corporation_members' do
+          before { @group.mailing_list_sender_filter = :corporation_members; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'group_members' do
+          before { @group.mailing_list_sender_filter = :group_members; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'officers' do
+          before { @group.mailing_list_sender_filter = :officers; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'group_officers' do
+          before { @group.mailing_list_sender_filter = :group_officers; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'global_officers' do
+          before { @group.mailing_list_sender_filter = :global_officers; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+      end
+    end
+
+    describe "for global officers" do
+      before do
+        @corporation = create :corporation_with_status_groups
+        @corporation << @group
+
+        @other_group = create :group
+        @officer_group = @other_group.create_officer_group name: 'President'
+        @officer_group.add_flag :global_officer
+        @officer_group.assign_user user
+      end
+      
+      describe "sender filter" do
+        describe '(empty)' do
+          before { @group.mailing_list_sender_filter = ""; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe '(nil)' do
+          before { @group.mailing_list_sender_filter = nil; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'open' do
+          before { @group.mailing_list_sender_filter = :open; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'users_with_account' do
+          before { @group.mailing_list_sender_filter = :users_with_account; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'corporation_members' do
+          before { @group.mailing_list_sender_filter = :corporation_members; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'group_members' do
+          before { @group.mailing_list_sender_filter = :group_members; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'officers' do
+          before { @group.mailing_list_sender_filter = :officers; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+        describe 'group_officers' do
+          before { @group.mailing_list_sender_filter = :group_officers; @group.save }
+          he { should_not be_able_to :create_post_for, @group }
+        end
+        describe 'global_officers' do
+          before { @group.mailing_list_sender_filter = :global_officers; @group.save }
+          he { should be_able_to :create_post_for, @group }
+        end
+      end
+    end
+
+  end
+end

--- a/spec/models/post_delivery_spec.rb
+++ b/spec/models/post_delivery_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe PostDelivery do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Hintergrund

In den letzten Monaten waren die Sende-Rechte für E-Mail-Verteiler einfach gefasst: Jedes Gruppen-Mitglied kann Posts für eine Gruppe erstellen. Eingehende Gruppen-E-Mails werden von allen Absendern akzeptiert.

Aktuelle Missbrauchsfälle zwingen uns, die Sende-Rechte restriktiver zu gestalten. Die einzelnen Anwendungsfälle sind jedoch so unterschiedlich, dass sich bislang keine allgemeine Regel für alle Gruppen finden konnte. Daher sollen die Sende-Rechte für jede Gruppe separat eingestellt werden können.

## Rechte-Auswahl

Dieser Pull-Request sieht folgende Auswahl für den Sende-Rechte für jede Gruppe vor, wobei **genau eine** der Optionen ausgewählt werden kann:

* Offen
* Wingolfiten  (in https://github.com/fiedl/wingolfsplattform)
* Benutzer mit Account
* Mitglieder der Korporation
* Mitglieder der Gruppe
* Amtsträger der Gruppe
* Amtsträger
* Bundesamtsträger

**Standard-Einstellung**: Wenn keine Option ausgewählt ist, gilt:

* Für alle Amtsträger-Gruppen (`OfficerGroup`) sind die Verteiler offen, damit auch Verteiler wie *info@xyz-wingolf.de* oder *vermietung@xyz-wingolf.de* funktionieren.
* Für Gruppen, die einer Korporation (`Corporation`) zugeordnet sind, dürfen alle Korporations-Mitglieder senden. Insbesondere dürfen so alle Aktiven des XYZ Wingolf auch an philister@xyz-wingolf.de schreiben.
* Für alle übrigen Gruppen (`Group`) dürfen Mitglieder der Gruppe senden.

## Posts und E-Mails

Die Berechtigungen, Posts über die Web-Oberfläche zu erstellen oder Posts per E-Mail einzuspeisen, werden nun nicht mehr unterschieden. Ferner steht die Option, ein sofortiges Absenden eines Posts zu erzwingen, nun nicht mehr nur Amtsträgern, sondern allen Sende-Berechtigten zur Verfügung, da die Option einem Versand via E-Mail gleichkommt.

Beide Vorgänge werden als Posts behandelt und im `PostsController` abgewickelt.

## Interface

In den Gruppen-Einstellungen können Gruppen-Administratoren die Sende-Berechtigung anpassen. Da sich die E-Mail-Verteiler jedoch noch im Beta-Stadium befinden, ist diese Einstellungsmöglichkeit derzeit nur Teilnehmern des Beta-Programmes zugänglich. Im Zweifel können die Einstellungen durch globale Administratoren vorgenommen werden.

<img width="648" alt="bildschirmfoto 2015-09-29 um 09 26 16" src="https://cloud.githubusercontent.com/assets/1679688/10206224/10f0dd70-67c6-11e5-9209-30d2bc7a91f0.png">

<img width="647" alt="bildschirmfoto 2015-09-29 um 09 26 23" src="https://cloud.githubusercontent.com/assets/1679688/10206227/13825bea-67c6-11e5-9051-792af1a2573b.png">

## Model

Die Einstellung wird für jede Gruppe als *String*-Attribut `Group#mailing_list_sender_filter` gespeichert:

* `open`
* `users_with_account`
* `corporation_members`
* `group_members`
* `officers`
* `group_officers`
* `global_officers`

Die Entscheidungslogik ist in `Group#user_matches_mailing_list_sender_filter?(user)` definiert, zu finden in `concerns/group_mailing_lists.rb`.

## Zurückweisung von E-Mails

Absender von abgesehenen E-Mails werden über die Zurückweisung ebenfalls per E-Mail benachrichtigt. Zurückweisung kann erfolgen, wenn

* keine Berechtigung zum Nachrichtenversand an eine Gruppe besteht, oder
* keine Empfängergruppe ermittelt werden konnte.

![bildschirmfoto 2015-09-30 um 22 42 35](https://cloud.githubusercontent.com/assets/1679688/10206216/04eb9df8-67c6-11e5-8169-5b723aa726e9.png)

## E-Mail-Versand per Queue

Beim Versand von Posts an Empfängergruppen mit mehr als tausend Teilnehmern brach der Queue-Worker bislang mit einem Timeout ab. Daher werden mit diesem Pull-Request nicht mehr alle Empfänger zusammen, sondern jeder einzeln in einem Queue-Eintrag behandelt. Der Versand-Status wird im Model `PostDelivery` (Tabelle `post_delivieries`) gespeichert, sodass der Versand-Status vom Absender detailliert in `posts#show` nachvollzogen werden kann.

![bildschirmfoto 2015-09-30 um 22 33 40](https://cloud.githubusercontent.com/assets/1679688/10206273/52253d18-67c6-11e5-858c-61c377b624e0.png)

## Siehe auch

* Trello-Karte im Entwicklungs-Board: https://trello.com/c/erclekyC/909-spam-mails-an-alle-wingolfiten
* Trello-Karte der Mumble-Sitzung: https://trello.com/c/jxV8NaR3/159-mumble-sitzung-am-29-09-2015
* Vorgangs-Kennung: *2015-Roe2goh4*
