### PR TITLE
Fix: Ability for changing Users#hidden (2015-Ahka7eik)

### DIFF
--- a/app/assets/stylesheets/your_platform/profiles.css.sass
+++ b/app/assets/stylesheets/your_platform/profiles.css.sass
@@ -13,7 +13,7 @@
 
 // Fix for bootstrap badges that include a radio button:
 .box .label
-  white-space: normal
+  //white-space: normal
   padding: 5px
   input
     top: -4px

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -111,7 +111,7 @@ class GroupsController < ApplicationController
         # Everything else, we encode as UTF-8.
         #
         csv_data = @list_export.to_csv
-        if list_preset.include? 'dpag_internetmarke'
+        if list_preset.try(:include?, 'dpag_internetmarke')
           csv_data = csv_data.encode('ISO-8859-1')
         else
           # See: http://railscasts.com/episodes/362-exporting-csv-and-excel

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -99,7 +99,9 @@ class UsersController < ApplicationController
       permitted_keys += [:avatar, :remove_avatar] if can? :update, @user
       permitted_keys += [:last_name, :name] if can? :change_last_name, @user
       permitted_keys += [:corporation_name] if can? :manage, @user
-      permitted_keys += [:create_account, :female, :add_to_group, :add_to_corporation, :hidden, :wingolfsblaetter_abo] if can? :manage, @user
+      permitted_keys += [:create_account, :female, :add_to_group, :add_to_corporation] if can? :manage, @user
+      permitted_keys += [:hidden] if can? :change_hidden, @user
+      permitted_keys += [:wingolfsblaetter_abo] if can? :update, @user
       permitted_keys += [:notification_policy] if can? :update, @user
     else  # user creation
       permitted_keys += [:first_name, :last_name, :female, :date_of_birth, :add_to_group, :add_to_corporation, :aktivmeldungsdatum, :study_address, :home_address, :work_address, :email, :phone, :mobile, :create_account] if can? :create, :aktivmeldung

--- a/app/views/users/_hidden_flag_switch.html.haml
+++ b/app/views/users/_hidden_flag_switch.html.haml
@@ -5,7 +5,7 @@
   - flagged = false
   - css_class = "unflagged"
 
-- if can? :manage, user
+- if can? :change_hidden, user
   %span{ :class => "user_hidden_flag show_only_in_edit_mode #{css_class} user_#{user.id}",
          :data => { user_id: user.id, update_json_url: user_path(user, format: :json) } }
     %span.label.label-danger

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -127,6 +127,11 @@ describe Ability do
         
         the_user.should_not be_able_to :destroy, @page
       end
+      
+      he "should be able to change the 'hidden' attribute of any user" do
+        @other_user = create :user
+        the_user.should be_able_to :change_hidden, @other_user
+      end
     end
     
     context "when the user is a group admin" do
@@ -139,6 +144,14 @@ describe Ability do
       he "should be able to update its profile fields" do
         @profile_field = @group.profile_fields.create(type: 'ProfileFieldTypes::Phone', value: '123')
         the_user.should be_able_to :update, @profile_field
+      end
+      
+      he "should not be able to change the 'hidden' attribute of the group members" do
+        @other_user = create :user; @group << @other_user
+        the_user.should_not be_able_to :change_hidden, @other_user
+      end
+      he "should not be able to change his own 'hidden' attribute" do
+        the_user.should_not be_able_to :change_hidden, user
       end
     end
     


### PR DESCRIPTION
## Hintergrund

Im Rahmen des Support-Tickets http://support.wingolfsplattform.org/tickets/239 von Thomas
Fischer wurde festgestellt, dass lokale Administratoren unbeabsichtigt das Recht haben, sich selbst oder andere Benutzer in ihrem Einflussbereich zu verstecken. Versteckte Benutzer sind aber von der Geschäftsstelle verwaltete Sonderfälle und sollen nicht von lokalen Administratoren verwaltet werden können.

## Akzeptanzkriterien

1. [x] Nur globale Administratoren dürfen das Attribut "Benutzer versteckt" verändern.

2. [x] Lokale Administratoren dürfen dieses Attribut nicht setzen.

3. [x] Model-Spec erstellen: https://github.com/fiedl/your_platform/compare/sf/fix-hidden-users?expand=1#diff-e9501dda6c23fd3e1076e2dff66d0f68R149

4. [x] Fall händisch testen für den Problemfall aus dem Ticket: Phil. Kai Kocher.
   ![bildschirmfoto 2015-10-01 um 14 28 59](https://cloud.githubusercontent.com/assets/1679688/10220768/03eac882-684a-11e5-9f53-d3670ce616d7.png)

5. [x] UI-Defekt beheben.
   ![bildschirmfoto 2015-10-01 um 14 29 57](https://cloud.githubusercontent.com/assets/1679688/10220776/084502ee-684a-11e5-93d8-f052dca0d4fb.png)

## Siehe auch

* Anforderungs-Dokument: /Dok 2015-Ahka7eik/, Back, 08.09.2015
* Beschluss: https://wingolfsplattform.org/pages/198-beschluesse-des-steuergremiums-vom-17-09-2015
* Beschlussfassung: https://wingolfsplattform.org/posts/474
* Protokoll: https://wingolfsplattform.org/attachments/812/2015-09-18_Beschlussfassung_2015-Ahka7eik_Versteckte_Benutzer.pdf
* https://trello.com/c/uLi610KN/156-mumble-sitzung-am-08-09-2015
* https://trello.com/c/j10db6CL/157-mumble-sitzung-am-15-09-2015