### PR TITLE
Blog-Einträge archivieren (2016-papahS9c)

### DIFF
--- a/app/assets/javascripts/your_platform/020-process.js.coffee
+++ b/app/assets/javascripts/your_platform/020-process.js.coffee
@@ -4,11 +4,9 @@ $(document).ready ->
   jQuery.fn.process = ->
     
     this.apply_edit_mode()
+    this.process_box_tools()
     this.process_comment_tools()
     this.process_mentions()
     
-    this.find('.box.event .edit_button').hide()
-    this.find('.box.event #ics_export').hide()
-        
     App.attachments.process($(this))
     App.galleries.process($(this))

--- a/app/assets/javascripts/your_platform/archivable.js.coffee
+++ b/app/assets/javascripts/your_platform/archivable.js.coffee
@@ -1,0 +1,45 @@
+send_archive_request = (url, true_or_false)->
+  $.ajax({
+    type: 'PUT',
+    url: url,
+    data: {
+      archived: true_or_false
+    },
+    #success: (result) -> # nothing to do
+    failure: (result) ->
+      alert('Es ist etwas schief gegangen. Bitte laden Sie die Seite neu.')
+  })
+
+$(document).on 'click', '.archive_button', (e)->
+  button = $(this)
+  url = button.attr('href')
+  boxes = button.closest('.page_with_attachments')
+  
+  button.effect('highlight')
+  boxes.hide 'fold', 300, ->
+    boxes.remove()
+    
+    # We trigger the request manually here in order not to
+    # suppress the animation before.
+    send_archive_request(url, true)
+  
+  return false
+
+$(document).on 'click', '.unarchive_button', (e)->
+  button = $(this)
+  url = button.attr('href')
+  boxes = button.closest('.page_with_attachments')
+  
+  button.effect 'highlight', ->
+    send_archive_request(url, false)
+    
+    boxes.find('.archived_label').hide 'blind'
+    button.hide 'blind'
+    
+  return false
+  
+$(document).on 'mouseenter', '.edit_button', ->
+  $(this).closest('.box').find('.archive_button').show('fade')
+  
+$(document).on 'mouseleave', '.panel-heading', ->
+  $(this).find('.archive_button').hide('fade')

--- a/app/assets/javascripts/your_platform/boxes.js.coffee
+++ b/app/assets/javascripts/your_platform/boxes.js.coffee
@@ -7,7 +7,35 @@ $(document).on 'save', '.box', ->
   
 $(document).on 'cancel', '.box', ->
   $(this).find('.content').removeClass 'currently_in_edit_mode'
-  
+
+
 $(document).ready ->
   $('.content_twoCols_right > div.col-xs-12').each -> 
     $(this).find('.box:first').addClass('first')
+
+$(document).ready ->
+  $(document).process_box_tools()
+
+$.fn.process_box_tools = ->
+  this.find('.box.event .edit_button').hide()
+  this.find('.box.event #ics_export').hide()
+  this.find('.archive_button').hide()
+
+  this.find('.box .panel-title .tool').each ->
+    tool = $(this)
+    box_toolbar = tool.closest('.panel-heading')
+      .find('span.box_toolbar').first()
+    tool.detach()
+    tool.prependTo(box_toolbar)
+    
+  # Hide 'edit' buttons for boxes where no .editable element 
+  # is included.
+  #
+  this.find('.edit_button:visible').each ->
+    edit_button = $(this)
+    box = edit_button.closest('.box')
+    edit_button.hide() if box.find('div.content').find('.editable,.show_only_in_edit_mode,.best_in_place').length == 0
+
+  this.find('.box_header_table td.box_toolbar').each ->
+    console.log $(this).find('a:visible,button:visible').length
+    $(this).remove() if $(this).find('a:visible,button:visible').length == 0

--- a/app/assets/javascripts/your_platform/edit_tools.js.coffee
+++ b/app/assets/javascripts/your_platform/edit_tools.js.coffee
@@ -5,15 +5,5 @@ ready = ->
   #
   $( "#site_tools .edit_button" ).hide()
 
-  # Hide 'edit' buttons for boxes where no .editable element is included.
-  #
-  hide_edit_button_if_not_needed = (edit_button)->
-    box = edit_button.closest('.box')
-    edit_button.hide() if box.find('div.content').find('.editable,.show_only_in_edit_mode,.best_in_place').length == 0
-
-  $( ".edit_button:visible" ).each( ->
-    hide_edit_button_if_not_needed $(this)
-  )
-
 $(document).ready(ready)
 

--- a/app/assets/stylesheets/your_platform/box.css.sass
+++ b/app/assets/stylesheets/your_platform/box.css.sass
@@ -18,3 +18,13 @@
   -moz-hyphens: auto
   -webkit-hyphens: auto
   hyphens: auto
+  
+
+.box .box_header_table
+  table-layout: fixed
+
+.box .panel-heading .tool
+  display: inline-block
+  
+.box td.box_toolbar
+  white-space: nowrap

--- a/app/assets/stylesheets/your_platform/events.css.sass
+++ b/app/assets/stylesheets/your_platform/events.css.sass
@@ -36,25 +36,6 @@ li.upcoming_event
 .event.name
   display: block
   
-.ics_export_buttons, .ics_abo_buttons
-  float: right
-  position: relative
-  top: -43px
-  left: -3px
-  height: 0
-  width: 600px
-  
-body.events .ics_export_buttons
-  top: -53px
-
-#ics_export, #ics_abo
-  float: right
-
-#ics_abo.btn
-  position: relative
-  top: -15px
-  left: 2px
-
 table.events_footer
   margin-left: 6px
   width: 98%

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -5,12 +5,15 @@ class ActivitiesController < ApplicationController
     authorize! :index, PublicActivity::Activity
     
     @user = User.find params[:user_id] if params[:user_id].present?
+    @page = Page.find params[:page_id] if params[:page_id].present?
+    @trackable = @user || @page
     
     @activities = PublicActivity::Activity
     @activities = @activities.where("(owner_type='User' and owner_id=?) or (trackable_type='User' and trackable_id=?)", @user.id, @user.id) if @user
+    @activities = @activities.where(trackable: @page) if @page
     @activities = @activities.where(owner: current_user.administrated_objects.select { |o| o.kind_of?(User) }) unless Role.of(current_user).global_admin?
     @activities = @activities.order('created_at desc').limit(100)
     
-    set_current_title "#{t(:activity_log)}: #{@user.try(:title)}"
+    set_current_title "#{t(:activity_log)}: #{@trackable.try(:title)}"
   end
 end

--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -33,6 +33,8 @@ class BlogPostsController < PagesController
   end
 
   def update
+    params[:blog_post] ||= {}
+    params[:blog_post][:archived] ||= params[:archived]  # required for archivable.js.coffee to work properly.
     set_inheritance_instance_variable
     @blog_post.update_attributes params[ :blog_post ].select { |k,v| v.present? && (v != "—")}
     respond_with_bip(@blog_post)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -52,6 +52,8 @@ class PagesController < ApplicationController
   end
 
   def update
+    params[:page] ||= {}
+    params[:page][:archived] ||= params[:archived]  # required for archivable.js.coffee to work properly.
     params[:blog_post] ||= params[:page]  # required for blog posts in respond_with_bip
     @page.update_attributes params[ :page ]
     respond_with_bip(@page)

--- a/app/helpers/archivable_helper.rb
+++ b/app/helpers/archivable_helper.rb
@@ -1,0 +1,21 @@
+module ArchivableHelper
+
+  # This inserts the 'archive' and 'unarchive' buttons for archivable
+  # objects. The PUT request is sent via ajax by the archivable.js.coffe
+  # script.
+  #
+  def archive_button(archivable)
+    if not archivable.archived?
+      link_to icon(:archive), archivable, class: 'btn btn-info archive_button', title: t(:archive_str, str: archivable.title)
+    elsif archivable.archived?
+      link_to icon(:undo), archivable, class: 'btn btn-info unarchive_button', title: t(:restore)
+    end
+  end
+  
+  def archived_label(archivable)
+    if archivable.archived?
+      content_tag(:span, t(:archived), class: 'label label-info archived_label')
+    end
+  end
+  
+end

--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -1,7 +1,7 @@
 module IconHelper
   
   def icon(icon_key)
-    if icon_key.to_s.in? ['beer', 'coffee', 'key', 'lock', 'unlock', 'unlock-alt']
+    if icon_key.to_s.in? ['beer', 'coffee', 'key', 'lock', 'unlock', 'unlock-alt', 'archive', 'undo', 'history']
       awesome_icon(icon_key)
     else
       glyphicon(icon_key.to_s.gsub('glyphicon-', ''))

--- a/app/helpers/tool_buttons_helper.rb
+++ b/app/helpers/tool_buttons_helper.rb
@@ -41,6 +41,9 @@ module ToolButtonsHelper
 
   def edit_button( options = {} )
     tool_button :edit, "edit black", t(:edit), options
+    #link_to '#', class: 'edit_button' do
+    #  tool_icon(:edit)
+    #end
   end
 
   def save_button( options = {} )

--- a/app/helpers/tool_buttons_helper.rb
+++ b/app/helpers/tool_buttons_helper.rb
@@ -40,7 +40,7 @@ module ToolButtonsHelper
   end
 
   def edit_button( options = {} )
-    tool_button :edit, "edit black", t(:edit), options
+    tool_button :edit, "edit black", "", {title: t(:edit)}.merge(options)
     #link_to '#', class: 'edit_button' do
     #  tool_icon(:edit)
     #end

--- a/app/models/concerns/archivable.rb
+++ b/app/models/concerns/archivable.rb
@@ -1,0 +1,27 @@
+concern :Archivable do
+  included do
+
+    attr_accessible :archived_at, :archived if defined? attr_accessible
+    attr_accessor :archived
+    
+    scope :archived, -> { where('archived_at IS NOT NULL') }
+    scope :not_archived, -> { where('archived_at IS NULL') }
+
+    def archived?
+      archived
+    end
+  
+    def archived
+      archived_at ? true : false
+    end
+  
+    def archived=(new_archived_setting)
+      if new_archived_setting.in? [false, 'false', 0, nil]
+        self.archived_at = nil
+      else
+        self.archived_at = Time.zone.now
+      end
+    end
+
+  end
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -12,17 +12,11 @@ class Page < ActiveRecord::Base
   serialize :redirect_to
   
   include PagePublicWebsite
+  include Archivable
   
-  scope :for_display, -> { includes(
-                            :ancestor_users,
-                            :ancestor_events, 
-                            :author, 
-                            :parent_pages, 
-                            :parent_users, 
-                            :parent_groups, 
-                            :parent_events
-                          )}
-
+  scope :for_display, -> { not_archived.includes(:ancestor_users, 
+    :ancestor_events, :author, :parent_pages, 
+    :parent_users, :parent_groups, :parent_events) }
 
   def not_empty?
     attachments.count > 0 or (content && content.length > 5)

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -1,13 +1,14 @@
-- if can? :destroy, @event
-  %p
-    = link_to "Veranstaltung wieder löschen", event_path(@event, format: 'json'), method: 'delete', class: 'btn btn-danger has_tooltip destroy_event', title: 'Die neue Veranstaltung kann bis zehn Minuten nach der Erstellung gelöscht werden, falls sie versehentlich erstellt wurde.', data: {redirect: root_path}
-
-%h1= best_in_place_if can?(:update, @event), @event, :name
+%h1
+  = best_in_place_if can?(:update, @event), @event, :name
+  - if can? :destroy, @event
+    .tool.destroy_event_tool
+      = link_to icon(:trash), event_path(@event, format: 'json'), method: 'delete', class: 'btn btn-danger destroy_event', title: 'Die neue Veranstaltung kann bis zehn Minuten nach der Erstellung gelöscht werden, falls sie versehentlich erstellt wurde.', data: {redirect: root_path}
+  - else  # This is a ui choice: If the event has just been created, we do not show the export button together with the destroy button in order not to clutter the tool bar.
+    .ics_export_buttons.tool
+      %a.btn.btn-default#ics_export{href: event_path(format: 'ics'), title: 'Dieses Ereignis als ICS-Datei (iCal) herunterladen, um es in einer Kalender-Anwendung zu öffnen.', data: {placement: 'top'}}
+        = icon :calendar
+        Kalender-Export
 %div
-  %span.ics_export_buttons
-    %a.btn.btn-default#ics_export.has_tooltip{href: event_path(format: 'ics'), title: 'Dieses Ereignis als ICS-Datei (iCal) herunterladen, um es in einer Kalender-Anwendung zu öffnen.', data: {placement: 'top'}}
-      = icon :calendar
-      Kalender-Export
   = render partial: 'events/event_details'
 
 = render partial: 'events/pictures'

--- a/app/views/layouts/_box.html.haml
+++ b/app/views/layouts/_box.html.haml
@@ -1,7 +1,7 @@
 .edit_mode_group
   %div{:class => "box panel panel-default #{box_class}"}
     .head.panel-heading
-      %table
+      %table.box_header_table
         %tr
           %td.box_heading
             %h1.panel-title= heading

--- a/app/views/pages/_page.html.haml
+++ b/app/views/pages/_page.html.haml
@@ -6,9 +6,11 @@
       = link_to(page) do
         = best_in_place_if can?(:update, page), page, :title, class: 'click_does_not_trigger_edit', activator: 'only_manual'
     - if can? :manage, page
-      .activities_tool.tool
+      .activities_tool.tool.do_not_show_in_edit_mode
         = link_to icon(:history), page_activities_path(page), class: 'btn btn-default', title: t(:show_page_activity_log)
-      
+    - if can? :destroy, page
+      .delete_page_tool.tool
+        = link_to icon(:trash), page_path(page, format: 'json'), method: 'delete', class: 'btn btn-danger destroy_page', title: I18n.t(:a_new_page_can_be_destroyed_within_ten_minutes), remote: true
     .archive_tools.tool
       = archived_label(page)
       = archive_button(page) if (page.type == 'BlogPost') && can?(:update, page)
@@ -30,9 +32,6 @@
     
     .page_footer
       %span.page_footer_box
-        - if can? :destroy, page
-          = link_to I18n.t(:destroy_page_again), page_path(page, format: 'json'), method: 'delete', class: 'btn btn-danger has_tooltip destroy_page right', title: I18n.t(:a_new_page_can_be_destroyed_within_ten_minutes), remote: true
-        
         - if page.author
           %span.page_author
             = link_to(page.author.title, page.author) + ", "

--- a/app/views/pages/_page.html.haml
+++ b/app/views/pages/_page.html.haml
@@ -5,6 +5,9 @@
     - else  # Blog Entries:
       = link_to(page) do
         = best_in_place_if can?(:update, page), page, :title, class: 'click_does_not_trigger_edit', activator: 'only_manual'
+    - if can? :manage, page
+      .activities_tool.tool
+        = link_to icon(:history), page_activities_path(page), class: 'btn btn-default', title: t(:show_page_activity_log)
       
     .archive_tools.tool
       = archived_label(page)

--- a/app/views/pages/_page.html.haml
+++ b/app/views/pages/_page.html.haml
@@ -1,41 +1,46 @@
-%h1
-  - if (page.try(:becomes, Page) == @navable.try(:becomes, Page)) and not @this_is_a_new_blog_post
-    = best_in_place_if can?(:update, page), page, :title
-  - else  # Blog Entries:
-    = link_to(page) do
-      = best_in_place_if can?(:update, page), page, :title, class: 'click_does_not_trigger_edit', activator: 'only_manual'
-%div.page
-  - if @navable != page and not @navable.in?(page.parents) and page.parents.first
-    .page_header
-      %span.right
-        = icon(:tag)
-        = link_to page.parents.first.title, page.parents.first
-  
-  - if (image_attachments = page.attachments_by_type("image")) && image_attachments.try(:any?)
-    #inline-pictures= render partial: 'attachments/pictures', locals: {attachments: image_attachments, inline: true}
-
-  %div.page_body
-    %div{ id: 'page_content', data: { mercury: 'full' } }
-      = best_in_place_if can?(:update, page), page, :content, as: :textarea, sanitize: false, activator: 'manual'
-    .show_only_in_edit_mode
-      = render partial: 'shared/markdown_help'
-  
-  .page_footer
-    %span.page_footer_box
-      - if can? :destroy, page
-        = link_to I18n.t(:destroy_page_again), page_path(page, format: 'json'), method: 'delete', class: 'btn btn-danger has_tooltip destroy_page right', title: I18n.t(:a_new_page_can_be_destroyed_within_ten_minutes), remote: true
+.page_with_attachments
+  %h1
+    - if (page.try(:becomes, Page) == @navable.try(:becomes, Page)) and not @this_is_a_new_blog_post
+      = best_in_place_if can?(:update, page), page, :title
+    - else  # Blog Entries:
+      = link_to(page) do
+        = best_in_place_if can?(:update, page), page, :title, class: 'click_does_not_trigger_edit', activator: 'only_manual'
       
-      - if page.author
-        %span.page_author
-          = link_to(page.author.title, page.author) + ", "
-      %span.page_created_at
-        = localize(page.created_at) if page.created_at
-      - if page.updated_at && page.updated_at > page.created_at + 1.hour
-        %span.page_updated_at
-          = " | "       
-          = t(:edited_at)
-          = localize(page.updated_at)
-
-#attachments
-  = render(partial: 'pages/videos', locals: {page: page}) 
-  = render(partial: 'pages/attachments', locals: {page: page})
+    .archive_tools.tool
+      = archived_label(page)
+      = archive_button(page) if (page.type == 'BlogPost') && can?(:update, page)
+  %div.page
+    - if @navable != page and not @navable.in?(page.parents) and page.parents.first
+      .page_header
+        %span.right
+          = icon(:tag)
+          = link_to page.parents.first.title, page.parents.first
+    
+    - if (image_attachments = page.attachments_by_type("image")) && image_attachments.try(:any?)
+      #inline-pictures= render partial: 'attachments/pictures', locals: {attachments: image_attachments, inline: true}
+  
+    %div.page_body
+      %div{ id: 'page_content', data: { mercury: 'full' } }
+        = best_in_place_if can?(:update, page), page, :content, as: :textarea, sanitize: false, activator: 'manual'
+      .show_only_in_edit_mode
+        = render partial: 'shared/markdown_help'
+    
+    .page_footer
+      %span.page_footer_box
+        - if can? :destroy, page
+          = link_to I18n.t(:destroy_page_again), page_path(page, format: 'json'), method: 'delete', class: 'btn btn-danger has_tooltip destroy_page right', title: I18n.t(:a_new_page_can_be_destroyed_within_ten_minutes), remote: true
+        
+        - if page.author
+          %span.page_author
+            = link_to(page.author.title, page.author) + ", "
+        %span.page_created_at
+          = localize(page.created_at) if page.created_at
+        - if page.updated_at && page.updated_at > page.created_at + 1.hour
+          %span.page_updated_at
+            = " | "       
+            = t(:edited_at)
+            = localize(page.updated_at)
+  
+  #attachments
+    = render(partial: 'pages/videos', locals: {page: page}) 
+    = render(partial: 'pages/attachments', locals: {page: page})

--- a/app/views/shared/_upcoming_events.html.haml
+++ b/app/views/shared/_upcoming_events.html.haml
@@ -6,16 +6,17 @@
 - # EventsHelper#group_to_create_the_event_in
 
 - if events.count > 0 || force_show
-  %h1.upcoming_events=t :events
-  %div
-    %span.ics_abo_buttons
+  %h1.upcoming_events
+    =t :events
+    .ics_abo_buttons.tool
       - if @group
-        %a.has_tooltip#ics_abo{href: group_events_url(group_id: @group.id, format: 'ics', protocol: 'webcal', token: current_user.account.auth_token), title: "Kalender-Abo (ICS, iCal): Veranstaltungen von '#{@group.name}' im Kalender auf dem eigenen Rechner abonnieren.", data: {placement: 'top'}}
+        %a#ics_abo{href: group_events_url(group_id: @group.id, format: 'ics', protocol: 'webcal', token: current_user.account.auth_token), title: "Kalender-Abo (ICS, iCal): Veranstaltungen von '#{@group.name}' im Kalender auf dem eigenen Rechner abonnieren.", data: {placement: 'top'}}
           = icon :calendar
       - elsif current_user
-        %a.btn.btn-default.has_tooltip#ics_abo{href: events_url(format: 'ics', protocol: 'webcal', token: current_user.account.auth_token), title: "Veranstaltungen, die mich betreffen, im Kalender auf dem eigenen Rechner abonnieren. Der Kalender wird dann automatisch auf dem Laufenden gehalten. (Empfohlen.)", data: {placement: 'top'}}
+        %a.btn.btn-default#ics_abo{href: events_url(format: 'ics', protocol: 'webcal', token: current_user.account.auth_token), title: "Veranstaltungen, die mich betreffen, im Kalender auf dem eigenen Rechner abonnieren. Der Kalender wird dann automatisch auf dem Laufenden gehalten. (Empfohlen.)", data: {placement: 'top'}}
           = icon :calendar
           Kalender-Abo!
+  %div
     %ul.upcoming_events
       = render partial: 'events/events_lis', locals: {events: events}
     .events_footer

--- a/config/locales/activities/de.yml
+++ b/config/locales/activities/de.yml
@@ -8,3 +8,5 @@ de:
   looks_at_officers: "sieht sich Amtsträger an"
   manages_group_settings: "nimmt Gruppen-Einstellungen vor"
   writes_a_message_to_group: "schreibt eine Nachricht an die Gruppe"
+  
+  show_page_activity_log: "Änderungs-Historie anzeigen"

--- a/config/locales/activities/en.yml
+++ b/config/locales/activities/en.yml
@@ -7,3 +7,6 @@ en:
   looks_at_group_profile: "is looking at group profile"
   looks_at_officers: "is looking up officers"
   manages_group_settings: "is managing group settings"
+  writes_a_message_to_group: "writes am message to a group"
+  
+  show_page_activity_log: "Show activity log"

--- a/config/locales/archivable/de.yml
+++ b/config/locales/archivable/de.yml
@@ -1,0 +1,4 @@
+de:
+  archived: Archiviert
+  archive_str: "'%{str}' archivieren"
+  restore: Wiederherstellen

--- a/config/locales/archivable/en.yml
+++ b/config/locales/archivable/en.yml
@@ -1,0 +1,4 @@
+en:
+  archived: Archived
+  archive_str: "Archive '%{str}'"
+  restore: Restore

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,7 @@ Rails.application.routes.draw do
   
   resources :pages do
     get :photo_contest, to: 'photo_contests#show'
+    get :activities, to: 'activities#index'
   end
   
   resources :projects

--- a/db/migrate/20160211120033_add_archived_at_to_pages.rb
+++ b/db/migrate/20160211120033_add_archived_at_to_pages.rb
@@ -1,0 +1,5 @@
+class AddArchivedAtToPages < ActiveRecord::Migration
+  def change
+    add_column :pages, :archived_at, :datetime
+  end
+end

--- a/demo_app/my_platform/db/migrate/20160215070331_add_archived_at_to_pages.your_platform.rb
+++ b/demo_app/my_platform/db/migrate/20160215070331_add_archived_at_to_pages.your_platform.rb
@@ -1,0 +1,6 @@
+# This migration comes from your_platform (originally 20160211120033)
+class AddArchivedAtToPages < ActiveRecord::Migration
+  def change
+    add_column :pages, :archived_at, :datetime
+  end
+end

--- a/demo_app/my_platform/db/schema.rb
+++ b/demo_app/my_platform/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151120091851) do
+ActiveRecord::Schema.define(version: 20160215070331) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -239,6 +239,7 @@ ActiveRecord::Schema.define(version: 20151120091851) do
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
     t.datetime "read_at"
+    t.datetime "failed_at"
   end
 
   create_table "pages", force: :cascade do |t|
@@ -249,6 +250,7 @@ ActiveRecord::Schema.define(version: 20151120091851) do
     t.string   "redirect_to",    limit: 255
     t.integer  "author_user_id", limit: 4
     t.string   "type",           limit: 255
+    t.datetime "archived_at"
   end
 
   add_index "pages", ["author_user_id"], name: "pages_author_user_id_fk", using: :btree
@@ -277,6 +279,7 @@ ActiveRecord::Schema.define(version: 20151120091851) do
     t.text     "entire_message",  limit: 65535
     t.string   "message_id",      limit: 255
     t.string   "content_type",    limit: 255
+    t.string   "sent_via",        limit: 255
   end
 
   add_index "posts", ["author_user_id"], name: "posts_author_user_id_fk", using: :btree

--- a/spec/features/edit_mode_after_clicking_a_link_spec.rb
+++ b/spec/features/edit_mode_after_clicking_a_link_spec.rb
@@ -3,16 +3,17 @@ require 'spec_helper'
 feature "edit mode after clicking a link" do
   include SessionSteps
 
-  scenario "switch to edit mode after clicking a link (turbolinks support)" do
+  scenario "switch to edit mode after clicking a link (turbolinks support)", :js do
     login(:admin)
     visit root_path
     
     # switch to another page (turbolinks)
+    first(:link, User.last.name).click
     first(:link, I18n.t(:my_profile)).click
 
     # edit mode should still work
     within(".box.section.contact_information") do
-      click_on I18n.t(:edit)
+      click_on I18n.t(:edit) # With the symbol-only edit button, this still works due to the 'edit' title.
       page.should have_content I18n.t(:add)
     end
 

--- a/spec/features/role_preview_spec.rb
+++ b/spec/features/role_preview_spec.rb
@@ -40,19 +40,19 @@ feature "Role Preview" do
     
     visit group_profile_path(@group)
     within ".box.first" do
-      page.should have_text I18n.t(:edit)
+      page.should have_selector '.edit_button'
     end
     within ".role-preview-switcher" do
       click_on I18n.t(:officer)
     end
     within ".box.first" do
-      page.should have_no_text I18n.t(:edit)
+      page.should have_no_selector '.edit_button'
     end
     within ".role-preview-switcher" do
       click_on I18n.t(:admin)
     end
     within ".box.first" do
-      page.should have_text I18n.t(:edit)
+      page.should have_selector '.edit_button'
     end
     
   end


### PR DESCRIPTION
Blog-Einträge können archiviert werden, wenn man annimmt, dass sie nicht mehr von Interesse sind.

Dadurch werden sie in den Blogs sowie auf der Startseite nicht mehr angezeigt. Sie können jedoch weiterhin über die Suche gefunden oder per Direkt-Link aufgerufen werden.

### Archivieren

<img width="682" alt="bildschirmfoto 2016-02-12 um 15 31 15" src="https://cloud.githubusercontent.com/assets/1679688/13010328/992a19fa-d1a1-11e5-99b3-30ba2fa09ef0.png">

### Wiederherstellen

<img width="615" alt="bildschirmfoto 2016-02-12 um 15 33 58" src="https://cloud.githubusercontent.com/assets/1679688/13010327/9909b70a-d1a1-11e5-974e-4b4030826e40.png">

### Verweise

* https://trello.com/c/zhwvnAEj/960-pages-archivieren-konnen-2016-papahs9c
* http://support.wingolfsplattform.org/tickets/603