### PR TITLE
Erweiterung der Listen-Exporte für Kassenwarte (Vorgang 2016-ahd3Aoje)

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -187,6 +187,8 @@ class GroupsController < ApplicationController
   
   def list_export_by_preset(list_preset)
     case list_preset
+    when 'name_list', '', nil
+      ListExports::NameList.from_group(@group)
     when 'member_development', 'join_statistics'
       ListExport.new(@group, list_preset)
     when 'dpag_internetmarken'

--- a/app/models/list_export.rb
+++ b/app/models/list_export.rb
@@ -51,8 +51,7 @@ class ListExport
     when 'join_statistics', 'join_and_persist_statistics'
       [:group] + ((Date.today.year - 25)..(Date.today.year)).to_a.reverse
     else
-      # This name_list is the default.
-      [:last_name, :first_name, :name_affix, :personal_title, :academic_degree]
+      raise "The list '#{preset.to_s}' is not defined."
     end
   end
   

--- a/app/models/list_export.rb
+++ b/app/models/list_export.rb
@@ -59,6 +59,8 @@ class ListExport
     columns.collect do |column|
       if column.kind_of? Symbol
         I18n.translate column.to_s.gsub('cached_', '').gsub('localized_', '')
+      elsif column.include?("_")
+        column.humanize
       else
         column
       end
@@ -118,12 +120,13 @@ class ListExport
       @leaf_groups = @group.leaf_groups
       # FIXME: The leaf groups should not return any officer group. Make this fix unneccessary:
       @leaf_groups -= @group.descendant_groups.where(name: ['officers', 'Amtsträger'])
-      @leaf_group_names = @leaf_groups.collect { |group| group.name }
+      @leaf_groups -= @group.descendant_groups.where(name: ['attendees', 'Teilnehmer', 'contact_people', 'Ansprechpartner'])
+      @leaf_group_names = @leaf_groups.map(&:name)
       @leaf_group_ids = @leaf_groups.collect { |group| group.id }
       # /FIXME - please uncomment:
       #@leaf_group_names = @leaf_groups.pluck(:name)
       #@leaf_group_ids = @leaf_groups.pluck(:id }
-      
+
       @group.members.collect do |user|
         user = user.becomes(ListExportUser)
         row = {
@@ -279,11 +282,15 @@ class HashWrapper
     @hash = hash
   end
   
+  def get(column_name)
+    @hash[column_name.to_s] || @hash[column_name.to_sym]
+  end
+  
   # This is a workaround for the to_xls gem, which requires to access the attributes
   # by method in order to write the columns in the correct order.
   #
-  def method_missing(method_name, *args, &block)  
-    @hash[method_name] || @hash[method_name.to_sym]
+  def method_missing(method_name, *args, &block)
+    get(method_name)
   end
 end
 

--- a/app/models/list_exports/base.rb
+++ b/app/models/list_exports/base.rb
@@ -44,6 +44,10 @@ module ListExports
       self.new(group.members.to_a, options.merge({group: group}))
     end
     
+    def group
+      @options[:group]
+    end
+    
     # The columns that are to be exported are listed here as array of Symbols or Strings.
     # During the export, these names are used either as methods on the ActiveRecord objects,
     # or as keys for the Hashes in the `data`.

--- a/app/models/list_exports/data_row.rb
+++ b/app/models/list_exports/data_row.rb
@@ -21,7 +21,7 @@ module ListExports
     
     def column(column_name)
       if @object.respond_to? :values
-        @object[column_name] || @object[column_name.to_sym]
+        @object[column_name.to_s] || @object[column_name.to_sym]
       elsif @object.respond_to? column_name
         @object.try(:send, column_name) 
       else

--- a/app/models/list_exports/data_row.rb
+++ b/app/models/list_exports/data_row.rb
@@ -16,7 +16,7 @@ module ListExports
     
     def initialize(object)
       @object = object
-      @object = @object.becomes ListExportUser if @object.kind_of? User
+      @object = @object.becomes ListExportUser if @object.kind_of? User and not @object.kind_of? ListExportUser
     end
     
     def column(column_name)

--- a/app/models/list_exports/list_export_user.rb
+++ b/app/models/list_exports/list_export_user.rb
@@ -3,6 +3,10 @@ module ListExports
     def personal_title_and_name
       "#{personal_title} #{name}".strip
     end
+    
+    # Name list
+    #
+    attr_accessor :member_since
   
     # Birthday, Date of Birth, Date of Death
     #

--- a/app/models/list_exports/name_list.rb
+++ b/app/models/list_exports/name_list.rb
@@ -3,8 +3,8 @@ module ListExports
   # This class produces simple name list export with some basic information that looks like this
   # in csv format with German locale:
   #
-  #     Nachname;Vorname;Namenszusatz;Persönlicher Titel;Akademischer Grad
-  #     Doe;Jonathan;\"\";Dr.;Dr. rer. nat.
+  #     Nachname;Vorname;Namenszusatz;Persönlicher Titel;Akademischer Grad;Mitglied in 'Gruppe XY' seit
+  #     Doe;Jonathan;\"\";Dr.;Dr. rer. nat.;12.12.1987
   #
   class NameList < Base
     
@@ -14,15 +14,33 @@ module ListExports
         :first_name,
         :name_affix,
         :personal_title,
-        :academic_degree
+        :academic_degree,
+        :member_since
       ]
     end
     
     # Sort the listed users last name and first name.
+    # Also, add the date of joining.
     #
     def data
-      super.sort_by do |user|
+      super.collect { |user|
+        user = user.becomes(ListExportUser)
+        user.member_since = I18n.localize(user.date_of_joining(group))
+        user
+      }.sort_by { |user|
         user.last_name + user.first_name
+      }
+    end
+    
+    # Don't just write "Member since". Write "Member of 'group xyz' since".
+    #
+    def headers
+      super.collect do |header|
+        if header == I18n.t(:member_since)
+          I18n.t(:member_of_str_since, str: group.title)
+        else
+          header
+        end
       end
     end
     

--- a/app/models/list_exports/name_list.rb
+++ b/app/models/list_exports/name_list.rb
@@ -1,0 +1,30 @@
+module ListExports
+  
+  # This class produces simple name list export with some basic information that looks like this
+  # in csv format with German locale:
+  #
+  #     Nachname;Vorname;Namenszusatz;Persönlicher Titel;Akademischer Grad
+  #     Doe;Jonathan;\"\";Dr.;Dr. rer. nat.
+  #
+  class NameList < Base
+    
+    def columns
+      [
+        :last_name,
+        :first_name,
+        :name_affix,
+        :personal_title,
+        :academic_degree
+      ]
+    end
+    
+    # Sort the listed users last name and first name.
+    #
+    def data
+      super.sort_by do |user|
+        user.last_name + user.first_name
+      end
+    end
+    
+  end
+end

--- a/app/models/list_exports/name_list.rb
+++ b/app/models/list_exports/name_list.rb
@@ -24,7 +24,7 @@ module ListExports
     #
     def data
       super.collect { |user|
-        user = user.becomes(ListExportUser)
+        user = user.becomes(ListExports::ListExportUser)
         user.member_since = I18n.localize(user.date_of_joining(group))
         user
       }.sort_by { |user|

--- a/app/models/user_mixins/memberships.rb
+++ b/app/models/user_mixins/memberships.rb
@@ -72,4 +72,16 @@ module UserMixins::Memberships
       )
     
   end
+  
+  def joined_at(group)
+    Rails.cache.fetch [self, 'joined_at', group] do
+      group.membership_of(self).valid_from
+    end
+  end    
+  
+  def date_of_joining(group)
+    Rails.cache.fetch [self, 'date_of_joining', group] do
+      self.joined_at(group).to_date
+    end
+  end
 end

--- a/config/locales/groups/de.yml
+++ b/config/locales/groups/de.yml
@@ -64,3 +64,5 @@ de:
   send_with_book_rate:            Als Büchersendung kennzeichnen
   exported_by:                    Exportiert von
   compact_address_format:         Kompaktes Adressformat
+  member_since:                   Mitglied seit
+  member_of_str_since:            "Mitglied in '%{str}' seit"

--- a/config/locales/groups/en.yml
+++ b/config/locales/groups/en.yml
@@ -46,6 +46,10 @@ en:
   email_list:                     Email list
   member_development:             Member Development
   current_age:                    Current age
+
+  member_since:                   Member since
+  member_of_str_since:            "Member of '%{str}' since"
+  
   pdf_files:                      PDF Files
   address_labels:                 Address Labels
   sender:                         Sender

--- a/spec/models/list_export_spec.rb
+++ b/spec/models/list_export_spec.rb
@@ -116,21 +116,4 @@ describe ListExport do
     end
   end
   
-  describe "name_list: " do
-    before do
-      @user.profile_fields.create(type: 'ProfileFieldTypes::AcademicDegree', value: "Dr. rer. nat.", label: :academic_degree)
-      @user.profile_fields.create(type: 'ProfileFieldTypes::General', value: "Dr.", label: :personal_title)
-      
-      @list_export = ListExport.new(@group.members, :name_list)
-    end
-    describe "#headers" do
-      subject { @list_export.headers }
-      it { should include 'Nachname', 'Vorname', 'Namenszusatz', 'Persönlicher Titel', 'Akademischer Grad' }
-    end
-    describe "#to_csv" do
-      subject { @list_export.to_csv }
-      it { should include "Nachname;Vorname;Namenszusatz;Persönlicher Titel;Akademischer Grad" }
-      it { should include "#{@user.last_name};#{@user.first_name};#{@user_title_without_name};Dr.;Dr. rer. nat." }
-    end
-  end
 end

--- a/spec/models/list_exports/name_list_spec.rb
+++ b/spec/models/list_exports/name_list_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe ListExports::NameList do
+  
+  before do
+    @group = create :group
+    @user = create :user, :with_address, first_name: "Jonathan", last_name: "Doe"
+    @user.address_profile_fields.first.update_attributes value: "Pariser Platz 1\n 10117 Berlin"
+    @user.profile_fields.create label: 'personal_title', value: "Dr."
+    @name_surrounding = @user.profile_fields.create type: "ProfileFieldTypes::NameSurrounding"
+    @name_surrounding = @user.profile_fields.where(type: "ProfileFieldTypes::NameSurrounding").first
+    @name_surrounding.text_below_name = "c./o. Foo Bar"
+    @name_surrounding.save
+    @user.profile_fields.create(type: 'ProfileFieldTypes::AcademicDegree', value: "Dr. rer. nat.", label: :academic_degree)
+    @user.profile_fields.create(type: 'ProfileFieldTypes::General', value: "Dr.", label: :personal_title)
+    @user_title_without_name = @user.title.gsub(@user.name, '').strip
+    @user_title_without_name = '""' if @user_title_without_name.blank? # to match the csv format
+    @group << @user
+
+    @list_export = ListExports::NameList.from_group(@group)
+  end
+
+  describe "#headers" do
+    subject { @list_export.headers }
+    it { should include 'Nachname', 'Vorname', 'Namenszusatz', 'Persönlicher Titel', 'Akademischer Grad' }
+  end
+
+  describe "#to_csv" do
+    subject { @list_export.to_csv }
+    it { should include "Nachname;Vorname;Namenszusatz;Persönlicher Titel;Akademischer Grad" }
+    it { should include "#{@user.last_name};#{@user.first_name};#{@user_title_without_name};Dr.;Dr. rer. nat." }
+  end
+  
+end

--- a/spec/models/list_exports/name_list_spec.rb
+++ b/spec/models/list_exports/name_list_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe ListExports::NameList do
   
   before do
-    @group = create :group
+    @group = create :group, name: 'MyGroup'
     @user = create :user, :with_address, first_name: "Jonathan", last_name: "Doe"
     @user.address_profile_fields.first.update_attributes value: "Pariser Platz 1\n 10117 Berlin"
     @user.profile_fields.create label: 'personal_title', value: "Dr."
@@ -22,13 +22,13 @@ describe ListExports::NameList do
 
   describe "#headers" do
     subject { @list_export.headers }
-    it { should include 'Nachname', 'Vorname', 'Namenszusatz', 'Persönlicher Titel', 'Akademischer Grad' }
+    it { should include 'Nachname', 'Vorname', 'Namenszusatz', 'Persönlicher Titel', 'Akademischer Grad', "Mitglied in 'MyGroup' seit" }
   end
 
   describe "#to_csv" do
     subject { @list_export.to_csv }
-    it { should include "Nachname;Vorname;Namenszusatz;Persönlicher Titel;Akademischer Grad" }
-    it { should include "#{@user.last_name};#{@user.first_name};#{@user_title_without_name};Dr.;Dr. rer. nat." }
+    it { should include "Nachname;Vorname;Namenszusatz;Persönlicher Titel;Akademischer Grad;Mitglied in 'MyGroup' seit" }
+    it { should include "#{@user.last_name};#{@user.first_name};#{@user_title_without_name};Dr.;Dr. rer. nat.;#{I18n.l(Date.today)}" }
   end
   
 end


### PR DESCRIPTION
Auf Anregung einiger Kassenwarte im Bund werden die vorhandenen Listen-Export-Funktionen erweitert, sodass ersichtlich ist, seit wann die Mitglieder in ihrem Status geführt werden.

## Wie kann ich einen Export durchführen?

Berechtigte Amtsträger finden über der Mitgliederliste den Knopf "Liste herunterladen", mit dem sie die Mitgliederliste in diverse Formate exportieren können.

Der Kassenwart des Leipziger Wingolfs etwa ruft die **Gruppe "[Philisterschaft des Leipziger Wingolfs](https://wingolfsplattform.org/groups/389-philisterschaft/members)"** auf und klickt auf **"Mitglieder"**.

Nach Klick auf **"Liste herunterladen"** öffnet sich das Export-Menü. Insbesondere finden sich dort eine **"Namensliste"** und die Liste **"Mitglieder-Entwicklung"**.

<img width="864" alt="bildschirmfoto 2016-02-17 um 14 34 09 kopie" src="https://cloud.githubusercontent.com/assets/1679688/13111047/e22996cc-d583-11e5-8f84-1b064c6b2961.png">

## Namensliste

Der Namensliste haben wir die **Spalte "Mitglied seit"** hinzugefügt, sodass ersichtlich ist, seit wann ein Mitglied in der Liste geführt wird.

<img width="1402" alt="bildschirmfoto 2016-02-17 um 14 51 28" src="https://cloud.githubusercontent.com/assets/1679688/13111421/048fd65c-d586-11e5-915d-3b99c41d85ff.png">

## Liste "Mitglieder-Entwicklung"

Sind Details über die Sub-Mitgliedschaften der Mitglieder erforderlich, ist die **Liste "Mitglieder-Entwicklung"** hilfreich, die wir 2014 auf Initiative des Wingolfs zu Wien erstellt hatten.

In dieser Mitgliederliste ist jeweils aufgeführt, wann das Mitglied in die jeweiligen Sub-Status-Listen aufgenommen wurde.

Im Falle der "Philisterschaft des Leipziger Wingolfs" ist ersichtlich, wann ein Mitglied "Philister" oder "Ehrenphilister" wurde.

<img width="1095" alt="bildschirmfoto 2016-02-17 um 14 53 15" src="https://cloud.githubusercontent.com/assets/1679688/13111473/44d1cf90-d586-11e5-98ab-75057a8c4b2d.png">

Sinnvoller ist diese Liste noch, wenn man nicht nur die "Philisterschaft des Leipziger Wingolfs" ansieht, sondern gleich den ganzen "Leipziger Wingolf". Dann ist nämlich ersichtlich, wann ein Mitglied jeweils "Fux", "Bursch" und "Philister" et cetera wurde.

<img width="1581" alt="bildschirmfoto 2016-02-17 um 14 56 47" src="https://cloud.githubusercontent.com/assets/1679688/13111561/bfc2e770-d586-11e5-997f-b3fae2ec0462.png">
