### PR TITLE
Enhance message with number of status groups, because names not unique

### DIFF
--- a/app/models/status_group.rb
+++ b/app/models/status_group.rb
@@ -25,7 +25,8 @@ class StatusGroup < Group
 
   def self.find_by_user_and_corporation(user, corporation)
     status_groups = (StatusGroup.find_all_by_corporation(corporation) & StatusGroup.find_all_by_user(user))
-    raise "Selection algorithm not unique, yet, for user #{user.id}. Please correct this. Found possible status groups: #{status_groups.map{ |x| x.name + ' (' + x.id.to_s + ')' }.join(', ') }." if status_groups.count > 1    status_groups.last
+    raise "Selection algorithm not unique, yet, for user #{user.id}. Please correct this. Found possible status groups: #{status_groups.map{ |x| x.name + ' (' + x.id.to_s + ')' }.join(', ') }." if status_groups.count > 1
+    status_groups.last
   end
 
 end

--- a/app/models/status_group.rb
+++ b/app/models/status_group.rb
@@ -25,7 +25,7 @@ class StatusGroup < Group
 
   def self.find_by_user_and_corporation(user, corporation)
     status_groups = (StatusGroup.find_all_by_corporation(corporation) & StatusGroup.find_all_by_user(user))
-    raise "Selection algorithm not unique, yet, for user #{user.id}. Please correct this. Found possible status groups: #{status_groups.map(&:name).join(', ')}." if status_groups.count > 1
+    raise "Selection algorithm not unique, yet, for user #{user.id}. Please correct this. Found possible status groups: #{status_groups.map({|x| x.name + ' (' + x.id + ')' }).join(', ')}." if status_groups.count > 1
     status_groups.last
   end
 

--- a/app/models/status_group.rb
+++ b/app/models/status_group.rb
@@ -25,8 +25,7 @@ class StatusGroup < Group
 
   def self.find_by_user_and_corporation(user, corporation)
     status_groups = (StatusGroup.find_all_by_corporation(corporation) & StatusGroup.find_all_by_user(user))
-    raise "Selection algorithm not unique, yet, for user #{user.id}. Please correct this. Found possible status groups: #{status_groups.map({|x| x.name + ' (' + x.id + ')' }).join(', ')}." if status_groups.count > 1
-    status_groups.last
+    raise "Selection algorithm not unique, yet, for user #{user.id}. Please correct this. Found possible status groups: #{status_groups.map{ |x| x.name + ' (' + x.id.to_s + ')' }.join(', ') }." if status_groups.count > 1    status_groups.last
   end
 
 end


### PR DESCRIPTION
As stated in http://support.wingolfsplattform.org/tickets/2294
the error message ist not leading to the right groups.

Selection algorithm not unique, yet, for user nnnn. Please correct this. Found possible status groups: s1, s2. 

With the change the message will be something like this

Selection algorithm not unique, yet, for user nnnn. Please correct this. Found possible status groups: s1 (333), s2(444).