### PR TITLE
Enhance message with number of officer group, because name is not unique

### DIFF
--- a/app/models/officer_group.rb
+++ b/app/models/officer_group.rb
@@ -11,7 +11,7 @@ class OfficerGroup < Group
   end
 
   def parent
-    ancestor_groups.flagged(:officers_parent).first || raise('officers group has no officers_parent!')
+    ancestor_groups.flagged(:officers_parent).first || raise("officer group #{self.id} has no officers_parent!")
   end
 
   def extensive_name


### PR DESCRIPTION
As stated in http://support.wingolfsplattform.org/tickets/2322
the error message ist not leading to the right group.

officers group has no officers_parent! 

With the change the message will be something like this

officers group nnn has no officers_parent!