### PR TITLE
2016 attempt to `renew_cache`

### DIFF
--- a/app/models/cache_additions.rb
+++ b/app/models/cache_additions.rb
@@ -13,3 +13,9 @@ module CacheAdditions
 end
 
 ActiveSupport::Cache::Store.include(CacheAdditions)
+
+class ActiveSupport::Cache::Entry
+  def created_at
+    @created_at
+  end
+end

--- a/app/models/dag_link.rb
+++ b/app/models/dag_link.rb
@@ -14,7 +14,8 @@ class DagLink < ActiveRecord::Base
   #
   # See: app/models/active_record_associations_patches.rb
   #
-  after_save { self.delay.delete_cache }
+  after_save { self.delay.renew_cache }
+  #after_save { self.delay.delete_cache }
   before_destroy :delete_cache
 
   include DagLinkRepair
@@ -28,5 +29,11 @@ class DagLink < ActiveRecord::Base
     ancestor.try(:delete_cache)
     descendant.try(:delete_cache)
   end
-  
+
+  def renew_cache
+    super
+    ancestor.try(:renew_cache)
+    descendant.try(:renew_cache)
+  end
+
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -58,12 +58,18 @@ class Group < ActiveRecord::Base
 
 
   after_create     :import_default_group_structure  # from GroupMixins::Import
-  after_save       { self.delay.delete_cache }
+  after_save       { self.delay.renew_cache }
 
   def delete_cache
     super
     ancestor_groups(true).each { |g| g.delete_cached(:leaf_groups); g.delete_cached(:status_groups) }
   end
+
+  def renew_cache
+    super
+    ancestor_groups(true).each { |g| g.renew_cached(:leaf_groups); g.renew_cached(:status_groups) }
+  end
+
 
   # General Properties
   # ==========================================================================================

--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -6,7 +6,7 @@ class ProfileField < ActiveRecord::Base
   belongs_to             :profileable, polymorphic: true
   has_many               :issues, as: :reference, dependent: :destroy
 
-  after_commit           :delete_cache
+  after_commit           :renew_cache
 
   include ProfileFieldMixins::HasChildProfileFields
 
@@ -95,6 +95,16 @@ class ProfileField < ActiveRecord::Base
     super
     parent.try(:delete_cache)
     profileable.delete_cache if profileable && profileable.respond_to?(:delete_cache)
+  end
+
+  def renew_cache
+    super
+    parent.try(:renew_cache)
+    profileable.renew_cache if profileable && profileable.respond_to?(:renew_cache)
+  end
+
+  def fill_cache
+    # Nothing to do here in the base class.
   end
 
   def children_count

--- a/app/models/profile_field_types/address.rb
+++ b/app/models/profile_field_types/address.rb
@@ -201,7 +201,7 @@ module ProfileFieldTypes
           else
             self.remove_flag :postal_address
           end
-          self.delete_cache
+          self.renew_cache
         end
       end
       def postal_address?

--- a/app/models/structureable_mixins/roles.rb
+++ b/app/models/structureable_mixins/roles.rb
@@ -13,305 +13,309 @@ module StructureableMixins::Roles
   extend ActiveSupport::Concern
 
   included do
-  end
 
-  def fill_cache
-    super if defined?(super)
-    if respond_to?(:child_groups) # TODO: Refactor this. It should be possible to find the admins for a user.
-      find_admins
-      admins_of_ancestors
-      admins_of_self_and_ancestors
-      officers_of_self_and_parent_groups
-      officers_groups_of_self_and_descendant_groups
-      officers_of_self_and_ancestors
-      officers_of_self_and_ancestor_groups
+    #def fill_cache
+    #  super if defined?(super)
+    #  if respond_to?(:child_groups) # TODO: Refactor this. It should be possible to find the admins for a user.
+    #    find_admins
+    #    admins_of_ancestors
+    #    admins_of_self_and_ancestors
+    #    officers_of_self_and_parent_groups
+    #    officers_groups_of_self_and_descendant_groups
+    #    officers_of_self_and_ancestors
+    #    officers_of_self_and_ancestor_groups
+    #  end
+    #end
+
+    def delete_cache
+      super
+      delete_caches_concerning_roles
     end
-  end
 
-  def delete_cache
-    super
-    delete_caches_concerning_roles
-  end
+    def renew_cache
+      #raise 'TODO'
+    end
 
-  def delete_caches_concerning_roles
-    if self.class.base_class.name == 'Group'
-      # For an admins_parent, this is called recursively until the original group
-      # is reached.
-      #
-      #   group
-      #     |---- officers_parent
-      #                |------------ admins_parent
-      #                |------------ some officer group
-      #
-      if has_flag?(:officers_parent) || has_flag?(:admins_parent)
-        parent_groups.each do |group|
-          group.delete_cache
-          if group.descendants.count > 0
-            bulk_delete_cached :admins_of_ancestors, group.descendants
-            bulk_delete_cached :admins_of_self_and_ancestors, group.descendants
-            bulk_delete_cached "*officers*", group.descendants
+    def delete_caches_concerning_roles
+      if self.class.base_class.name == 'Group'
+        # For an admins_parent, this is called recursively until the original group
+        # is reached.
+        #
+        #   group
+        #     |---- officers_parent
+        #                |------------ admins_parent
+        #                |------------ some officer group
+        #
+        if has_flag?(:officers_parent) || has_flag?(:admins_parent)
+          parent_groups.each do |group|
+            group.delete_cache
+            if group.descendants.count > 0
+              bulk_delete_cached :admins_of_ancestors, group.descendants
+              bulk_delete_cached :admins_of_self_and_ancestors, group.descendants
+              bulk_delete_cached "*officers*", group.descendants
+            end
           end
         end
       end
     end
-  end
 
 
-  # Officers
-  # ==========================================================================================
-  #
-  # Each structureable object may have officers, e.g. the president of the organization.
-  # Officers are collected in a subgroup with the flag :officers_parent. This
-  # officers_parent group may also have subgroups. But, of course, the officers_parent
-  # group must not have another officers_parent subgroup.
-  #
-  # Calling `some_structureable_object.officers` lists all officer users of the structureable
-  # itself **and of the sub groups** of the structureable object.
-  #
+    # Officers
+    # ==========================================================================================
+    #
+    # Each structureable object may have officers, e.g. the president of the organization.
+    # Officers are collected in a subgroup with the flag :officers_parent. This
+    # officers_parent group may also have subgroups. But, of course, the officers_parent
+    # group must not have another officers_parent subgroup.
+    #
+    # Calling `some_structureable_object.officers` lists all officer users of the structureable
+    # itself **and of the sub groups** of the structureable object.
+    #
 
-  def find_officers_parent_group
-    find_special_group(:officers_parent)
-  end
-
-  def create_officers_parent_group
-    if self.ancestor_groups(true).find_all_by_flag(:officers_parent).count == 0 and not self.has_flag?(:officers_parent)
-      # Do not allow officer cascades.
-      create_special_group(:officers_parent)
+    def find_officers_parent_group
+      find_special_group(:officers_parent)
     end
-  end
 
-  def find_or_create_officers_parent_group
-    find_officers_parent_group || create_officers_parent_group
-  end
-
-  def officers_parent
-    find_or_create_officers_parent_group
-  end
-
-  def officers_parent!
-    find_officers_parent_group || raise('special group :officers_parent does not exist.')
-  end
-
-
-  def descendant_officer_groups
-    self.descendant_groups.where(type: 'OfficerGroup')
-  end
-
-  def create_officer_group(attrs = {name: "New Office"})
-    g = officers_parent.child_groups.create(attrs)
-    g.update_attribute :type, "OfficerGroup"
-    return Group.find(g.id)  # in order to have it the OfficerGroup class
-  end
-
-
-  # This method returns all officer_parent groups of the structureable object itself
-  # and of the descendant groups of the structureable object.
-  #
-  def find_officers_parent_groups_of_self_and_of_descendant_groups
-    [self.find_officers_parent_group] + self.descendant_groups.find_all_by_flag(:officers_parent) - [nil]
-  end
-
-  # This method lists all officer groups of the group, i.e. all subgroups of the
-  # officers_parent group.
-  #
-  def find_officers_groups
-    self.find_officers_parent_group.try(:descendant_officer_groups) || []
-  end
-  def officers_groups
-    self.officers_parent.descendant_officer_groups
-  end
-
-  def direct_officers
-    self.find_officers_parent_group.try(:members) || []
-  end
-
-  def officers_of_self_and_parent_groups
-    cached do
-      direct_officers + (parent_groups.collect { |parent_group| parent_group.direct_officers }.flatten)
+    def create_officers_parent_group
+      if self.ancestor_groups(true).find_all_by_flag(:officers_parent).count == 0 and not self.has_flag?(:officers_parent)
+        # Do not allow officer cascades.
+        create_special_group(:officers_parent)
+      end
     end
-  end
 
-  def officers_groups_of_self_and_descendant_groups
-    cached do
+    def find_or_create_officers_parent_group
+      find_officers_parent_group || create_officers_parent_group
+    end
+
+    def officers_parent
+      find_or_create_officers_parent_group
+    end
+
+    def officers_parent!
+      find_officers_parent_group || raise('special group :officers_parent does not exist.')
+    end
+
+
+    def descendant_officer_groups
+      self.descendant_groups.where(type: 'OfficerGroup')
+    end
+
+    def create_officer_group(attrs = {name: "New Office"})
+      g = officers_parent.child_groups.create(attrs)
+      g.update_attribute :type, "OfficerGroup"
+      return Group.find(g.id)  # in order to have it the OfficerGroup class
+    end
+
+
+    # This method returns all officer_parent groups of the structureable object itself
+    # and of the descendant groups of the structureable object.
+    #
+    def find_officers_parent_groups_of_self_and_of_descendant_groups
+      [self.find_officers_parent_group] + self.descendant_groups.find_all_by_flag(:officers_parent) - [nil]
+    end
+
+    # This method lists all officer groups of the group, i.e. all subgroups of the
+    # officers_parent group.
+    #
+    def find_officers_groups
+      self.find_officers_parent_group.try(:descendant_officer_groups) || []
+    end
+    def officers_groups
+      self.officers_parent.descendant_officer_groups
+    end
+
+    def direct_officers
+      self.find_officers_parent_group.try(:members) || []
+    end
+
+    def officers_of_self_and_parent_groups
+      cached do
+        direct_officers + (parent_groups.collect { |parent_group| parent_group.direct_officers }.flatten)
+      end
+    end
+
+    def officers_groups_of_self_and_descendant_groups
+      cached do
+        self.find_officers_parent_groups_of_self_and_of_descendant_groups.collect do |officers_parent|
+          officers_parent.descendant_officer_groups
+        end.flatten.uniq
+      end
+    end
+
+    def find_officers
+      cached do
+        if respond_to? :child_groups
+          find_officers_parent_group.try(:members)
+        end || []
+      end
+    end
+
+    def officers_of_ancestors
+      cached { ancestors.collect { |ancestor| ancestor.find_officers }.flatten }
+    end
+
+    def officers_of_ancestor_groups
+      cached { ancestor_groups.collect { |ancestor| ancestor.find_officers }.flatten }
+    end
+
+    def officers_of_self_and_ancestors
+      cached { find_officers + officers_of_ancestors }
+    end
+
+    def officers_of_self_and_ancestor_groups
+      cached { find_officers + officers_of_ancestor_groups }
+    end
+
+    # This method returns all officer users, as well all of this group as of its subgroups.
+    #
+    def officers
       self.find_officers_parent_groups_of_self_and_of_descendant_groups.collect do |officers_parent|
-        officers_parent.descendant_officer_groups
+        officers_parent.members
       end.flatten.uniq
     end
-  end
 
-  def find_officers
-    cached do
-      if respond_to? :child_groups
-        find_officers_parent_group.try(:members)
+
+    # Admins
+    # ==========================================================================================
+    #
+    # Each structureable object may have admins (users), which are collected in the
+    # `admins_parent` special group of the structureable object, which is a subgroup
+    # of the officers_parent subgroup of the structureable object.
+    #
+    #     my_structureable
+    #             |----------- officers_parent
+    #                                |----------- admins_parent
+    #
+    # One can access or assign the admins of the structureable object by calling:
+    #
+    #   my_structureable.admins          # => Array of users
+    #   my_structureable.assign_admin user
+    #
+
+    def find_admins_parent_group
+      find_special_group(:admins_parent, parent_element: find_officers_parent_group )
+    end
+
+    def create_admins_parent_group
+      delete_cached(:find_admins)
+      create_special_group :admins_parent, parent_element: find_or_create_officers_parent_group, type: 'OfficerGroup'
+    end
+
+    def find_or_create_admins_parent_group
+        find_special_group(:admins_parent, parent_element: find_or_create_officers_parent_group) or
+        begin
+          delete_cached(:find_admins)
+          create_special_group :admins_parent, parent_element: find_or_create_officers_parent_group, type: 'OfficerGroup'
+        rescue
+          nil
+        end
+    end
+
+    def admins_parent
+      find_or_create_admins_parent_group
+    end
+
+    def admins_parent!
+      find_admins_parent_group || raise('special group :admins_parent does not exist.')
+    end
+
+    def admins
+      find_or_create_admins_parent_group.try(:members) || []
+    end
+
+    def assign_admin(user, options = {})
+      admins_parent.assign_user user, options
+    end
+
+    def find_admins
+      cached do
+        if respond_to? :child_groups
+          find_admins_parent_group.try(:members)
+        end || []
       end || []
     end
-  end
 
-  def officers_of_ancestors
-    cached { ancestors.collect { |ancestor| ancestor.find_officers }.flatten }
-  end
+    def admins_of_ancestors
+      cached { ancestors.collect { |ancestor| ancestor.find_admins }.flatten }
+    end
 
-  def officers_of_ancestor_groups
-    cached { ancestor_groups.collect { |ancestor| ancestor.find_officers }.flatten }
-  end
+    def admins_of_ancestor_groups
+      cached { ancestor_groups.collect { |ancestor| ancestor.find_admins }.flatten }
+    end
 
-  def officers_of_self_and_ancestors
-    cached { find_officers + officers_of_ancestors }
-  end
+    def admins_of_self_and_ancestors
+      cached { find_admins + admins_of_ancestors }
+    end
 
-  def officers_of_self_and_ancestor_groups
-    cached { find_officers + officers_of_ancestor_groups }
-  end
+    def local_admins
+      cached { (admins_of_self_and_ancestors - Group.global_admins.members).uniq }
+    end
 
-  # This method returns all officer users, as well all of this group as of its subgroups.
-  #
-  def officers
-    self.find_officers_parent_groups_of_self_and_of_descendant_groups.collect do |officers_parent|
-      officers_parent.members
-    end.flatten.uniq
-  end
-
-
-  # Admins
-  # ==========================================================================================
-  #
-  # Each structureable object may have admins (users), which are collected in the
-  # `admins_parent` special group of the structureable object, which is a subgroup
-  # of the officers_parent subgroup of the structureable object.
-  #
-  #     my_structureable
-  #             |----------- officers_parent
-  #                                |----------- admins_parent
-  #
-  # One can access or assign the admins of the structureable object by calling:
-  #
-  #   my_structureable.admins          # => Array of users
-  #   my_structureable.assign_admin user
-  #
-
-  def find_admins_parent_group
-    find_special_group(:admins_parent, parent_element: find_officers_parent_group )
-  end
-
-  def create_admins_parent_group
-    delete_cached(:find_admins)
-    create_special_group :admins_parent, parent_element: find_or_create_officers_parent_group, type: 'OfficerGroup'
-  end
-
-  def find_or_create_admins_parent_group
-      find_special_group(:admins_parent, parent_element: find_or_create_officers_parent_group) or
-      begin
-        delete_cached(:find_admins)
-        create_special_group :admins_parent, parent_element: find_or_create_officers_parent_group, type: 'OfficerGroup'
-      rescue
-        nil
-      end
-  end
-
-  def admins_parent
-    find_or_create_admins_parent_group
-  end
-
-  def admins_parent!
-    find_admins_parent_group || raise('special group :admins_parent does not exist.')
-  end
-
-  def admins
-    find_or_create_admins_parent_group.try(:members) || []
-  end
-
-  def assign_admin(user, options = {})
-    admins_parent.assign_user user, options
-  end
-
-  def find_admins
-    cached do
-      if respond_to? :child_groups
-        find_admins_parent_group.try(:members)
-      end || []
-    end || []
-  end
-
-  def admins_of_ancestors
-    cached { ancestors.collect { |ancestor| ancestor.find_admins }.flatten }
-  end
-
-  def admins_of_ancestor_groups
-    cached { ancestor_groups.collect { |ancestor| ancestor.find_admins }.flatten }
-  end
-
-  def admins_of_self_and_ancestors
-    cached { find_admins + admins_of_ancestors }
-  end
-
-  def local_admins
-    cached { (admins_of_self_and_ancestors - Group.global_admins.members).uniq }
-  end
-
-  def responsible_admins
-    cached do
-      if local_admins.any?
-        local_admins
-      elsif Role.non_technical_global_admins.any?
-        Role.non_technical_global_admins
-      else
-        Role.global_admins
+    def responsible_admins
+      cached do
+        if local_admins.any?
+          local_admins
+        elsif Role.non_technical_global_admins.any?
+          Role.non_technical_global_admins
+        else
+          Role.global_admins
+        end
       end
     end
-  end
-  def responsible_admin
-    responsible_admins.first
-  end
-  def responsible_admin_id
-    responsible_admin.try(:id)
-  end
+    def responsible_admin
+      responsible_admins.first
+    end
+    def responsible_admin_id
+      responsible_admin.try(:id)
+    end
 
 
-  # Main Admins
-  # ==========================================================================================
-  #
-  # Main admins are also admins. But they have more rights and responsibilities.
-  # For example, they may edit the critical properties of the objects they administrate.
-  #
-  # Since main admins are also admins, the special group structure looks like this:
-  #
-  #     my_structureable
-  #             |----------- officers_parent
-  #                                |----------- admins_parent
-  #                                                 |---------- main_admins_parent
-  #
-  # One can access or assign the main admins of the structureable object by calling:
-  #
-  #   my_structureable.main_admins          # => Array of users
-  #   my_structureable.main_assign_admin user
-  #
+    # Main Admins
+    # ==========================================================================================
+    #
+    # Main admins are also admins. But they have more rights and responsibilities.
+    # For example, they may edit the critical properties of the objects they administrate.
+    #
+    # Since main admins are also admins, the special group structure looks like this:
+    #
+    #     my_structureable
+    #             |----------- officers_parent
+    #                                |----------- admins_parent
+    #                                                 |---------- main_admins_parent
+    #
+    # One can access or assign the main admins of the structureable object by calling:
+    #
+    #   my_structureable.main_admins          # => Array of users
+    #   my_structureable.main_assign_admin user
+    #
 
-  def find_main_admins_parent_group
-    find_special_group(:main_admins_parent, parent_element: find_admins_parent_group)
+    def find_main_admins_parent_group
+      find_special_group(:main_admins_parent, parent_element: find_admins_parent_group)
+    end
+
+    def create_main_admins_parent_group
+      create_special_group :main_admins_parent, parent_element: find_or_create_admins_parent_group, type: 'OfficerGroup'
+    end
+
+    def find_or_create_main_admins_parent_group
+      find_or_create_special_group :main_admins_parent, parent_element: find_or_create_admins_parent_group, type: 'OfficerGroup'
+    end
+
+    def main_admins_parent
+      find_or_create_main_admins_parent_group
+    end
+
+    def main_admins_parent!
+      find_main_admins_parent_group || raise('special group :main_admins_parent does not exist.')
+    end
+
+    def main_admins
+      main_admins_parent.members
+    end
+
+    def assign_main_admin(user, options = {})
+      main_admins_parent.assign_user user, options
+    end
+
   end
-
-  def create_main_admins_parent_group
-    create_special_group :main_admins_parent, parent_element: find_or_create_admins_parent_group, type: 'OfficerGroup'
-  end
-
-  def find_or_create_main_admins_parent_group
-    find_or_create_special_group :main_admins_parent, parent_element: find_or_create_admins_parent_group, type: 'OfficerGroup'
-  end
-
-  def main_admins_parent
-    find_or_create_main_admins_parent_group
-  end
-
-  def main_admins_parent!
-    find_main_admins_parent_group || raise('special group :main_admins_parent does not exist.')
-  end
-
-  def main_admins
-    main_admins_parent.members
-  end
-
-  def assign_main_admin(user, options = {})
-    main_admins_parent.assign_user user, options
-  end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@ class User < ActiveRecord::Base
   before_save               :generate_alias_if_necessary, :capitalize_name
   before_save               :build_account_if_requested
   after_save                :add_to_group_if_requested
-  after_save                { self.delay.delete_cache }
+  after_save                { self.delay.renew_cache }
 
   # after_commit     					:delete_cache, prepend: true
   # before_destroy    				:delete_cache, prepend: true

--- a/app/models/user_group_membership_mixins/validity_range_for_indirect_memberships.rb
+++ b/app/models/user_group_membership_mixins/validity_range_for_indirect_memberships.rb
@@ -66,6 +66,7 @@ module UserGroupMembershipMixins::ValidityRangeForIndirectMemberships
 
   def valid_from
     self.direct? ? super : (@valid_from ||= cached { earliest_direct_membership.try(:valid_from) })
+    #cached { self.direct? ? super : earliest_direct_membership.try(:valid_from) }
   end
   def valid_from=( valid_from )
     if self.direct?

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -193,6 +193,9 @@ describe Ability do
 
       describe "(events)" do
         he "should be able to create an event in his group" do
+
+          #@group.reload # löst das Problem. Warum?
+
           the_user.should be_able_to :create_event, @group
         end
         he "should be able to update events in his group" do


### PR DESCRIPTION
Our model caching system extends `ActiveRecord::Base` with a `delete_cache` method. Whenever substantial changes are made to an active record object, a `delay.delete_cache` is called, causing to reset the caches for this object. Whenever the cached methods are requested during a following GET request, the cache is rebuilt on the fly.

To improve performance, this idea attempts to recreate the cache in the background rather than just deleting it. The idea is to call `delay.renew_cache` rather than `delay.delete_cache`.

Internal notes and research on trello:
https://trello.com/c/6dNTE3FL/1084-renew-cache