### PR TITLE
Call method with correct parameters

### DIFF
--- a/app/models/status_group.rb
+++ b/app/models/status_group.rb
@@ -18,7 +18,7 @@ class StatusGroup < Group
     status_groups = corporation.status_groups & user.status_groups
 
     if status_groups.count > 1
-      Membership.apply_gap_correction(user, corporation, "Memberships::Status")
+      Membership.apply_gap_correction(user, corporation, type: "Memberships::Status")
       status_groups = corporation.status_groups & user.status_groups
     end
 


### PR DESCRIPTION
Call method to apply gap correction with correct parameters.
To prevent the error "no implicit conversion of Symbol into Integer " in 
your_platform/app/models/concerns/membership_gap_correction.rb:23:in `[]' 
your_platform/app/models/concerns/membership_gap_correction.rb:23:in `apply_gap_correction'

As it happened in Brimir in https://support.wingolfsplattform.org/tickets/15272