### PR TITLE
Feld "Typ" aus Attachment Ansicht entfernt

### DIFF
--- a/app/views/attachments/_attachment.html.haml
+++ b/app/views/attachments/_attachment.html.haml
@@ -24,11 +24,6 @@
         = "#{t(:author)}: "
         = user_best_in_place_if can?(:manage, attachment), attachment, :author_title
 
-      - if show_technical_information && can?(:manage, attachment)
-        %p.attachment.type
-        = "#{t(:type)}: "
-        = best_in_place attachment, :type
-
       - if show_technical_information
         %p.attachment.filesize
           = attachment.file_size_human


### PR DESCRIPTION
Es gab ein Freitextfeld "Typ", welches imstande war, bei Fehlbenutzung alle Pages auf denen das attachment zu finden ist, zu brechen

https://trello.com/c/2v9xKO0p/1460