### PR TITLE
Fix timezone removement

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -98,7 +98,7 @@ class Event < ApplicationRecord
   # ==========================================================================================
 
   def localized_start_at
-    I18n.localize start_at.to_time if start_at.present?
+    I18n.localize start_at if start_at.present?
   end
   def localized_start_at=(string)
     attribute_will_change! :start_at


### PR DESCRIPTION
Changed `start_at.to_time` to `start_at` (so removed `.to_time`) because it discards the timezone.

https://trello.com/c/50SnqbDZ/1442-zeitzonen-problem-bei-veranstaltungen