### PR TITLE
Add fix to end time (remvoed .to_time because it discards the timezone)

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -106,7 +106,7 @@ class Event < ApplicationRecord
   end
 
   def localized_end_at
-    I18n.localize end_at.to_time if end_at.present?
+    I18n.localize end_at if end_at.present?
   end
   def localized_end_at=(string)
     attribute_will_change! :end_at


### PR DESCRIPTION
https://trello.com/c/50SnqbDZ/1442-zeitzonen-problem-bei-veranstaltungen