### PR TITLE
Verbesserte Mailing-Listen

### DIFF
--- a/app/jobs/deliver_email_message_job.rb
+++ b/app/jobs/deliver_email_message_job.rb
@@ -1,0 +1,10 @@
+class DeliverEmailMessageJob < ApplicaionJob
+  queue_as :mailgate
+
+  def perform(message)
+    # TODO: Test whether serializing long messages works.
+    # TODO: Test whether serializing UTF-8 🍕 works.
+
+    message.deliver_with_action_mailer_now
+  end
+end

--- a/app/jobs/deliver_email_message_job.rb
+++ b/app/jobs/deliver_email_message_job.rb
@@ -1,10 +1,15 @@
-class DeliverEmailMessageJob < ApplicaionJob
+class DeliverEmailMessageJob < ApplicationJob
   queue_as :mailgate
 
-  def perform(message)
+  def perform(raw_message:, envelope_attributes: {})
     # TODO: Test whether serializing long messages works.
     # TODO: Test whether serializing UTF-8 🍕 works.
 
+    message = Mail::Message.new(raw_message)
+    envelope_attributes.each do |key, value|
+      message.send "#{key}=", value
+    end
     message.deliver_with_action_mailer_now
   end
+
 end

--- a/app/mailers/base_mailer.rb
+++ b/app/mailers/base_mailer.rb
@@ -13,4 +13,8 @@ class BaseMailer < ActionMailer::Base
   helper ApplicationHelper
   default from: "\"#{AppVersion.app_name}\" <#{Setting.support_email}>"
 
+  def self.delivery_errors_address
+    "delivery-errors@#{AppVersion.email_domain}"
+  end
+
 end

--- a/app/models/incoming_mails/group_mailing_list_mail.rb
+++ b/app/models/incoming_mails/group_mailing_list_mail.rb
@@ -20,7 +20,7 @@ class IncomingMails::GroupMailingListMail < IncomingMail
         new_message.to = formatted_to
         new_message.smtp_envelope_to = user.email
         fill_in_placeholders new_message, from_user: sender_user, to_user: user
-        new_message.deliver_with_action_mailer_now
+        new_message.delay.deliver_with_action_mailer_now
       end
       deliveries
     else

--- a/app/models/incoming_mails/group_mailing_list_mail.rb
+++ b/app/models/incoming_mails/group_mailing_list_mail.rb
@@ -15,6 +15,7 @@ class IncomingMails::GroupMailingListMail < IncomingMail
 
         new_message.from = formatted_from
         new_message.reply_to = formatted_from
+        new_message.return_path = BaseMailer.default[:from]
         new_message.sender = BaseMailer.default[:from]
         new_message.to = formatted_to
         new_message.smtp_envelope_to = user.email

--- a/app/models/incoming_mails/group_mailing_list_mail.rb
+++ b/app/models/incoming_mails/group_mailing_list_mail.rb
@@ -20,7 +20,7 @@ class IncomingMails::GroupMailingListMail < IncomingMail
         new_message.to = formatted_to
         new_message.smtp_envelope_to = user.email
         fill_in_placeholders new_message, from_user: sender_user, to_user: user
-        new_message.delay.deliver_with_action_mailer_now
+        new_message.deliver_with_action_mailer_later
       end
       deliveries
     else

--- a/app/models/incoming_mails/group_mailing_list_mail.rb
+++ b/app/models/incoming_mails/group_mailing_list_mail.rb
@@ -15,7 +15,7 @@ class IncomingMails::GroupMailingListMail < IncomingMail
 
         new_message.from = formatted_from
         new_message.reply_to = formatted_from
-        new_message.return_path = BaseMailer.default[:from]
+        new_message.return_path = BaseMailer.delivery_errors_address
         new_message.sender = BaseMailer.default[:from]
         new_message.to = formatted_to
         new_message.smtp_envelope_to = user.email

--- a/core_ext/mail/message.rb
+++ b/core_ext/mail/message.rb
@@ -127,7 +127,7 @@ module YourPlatformMailMessageExtensions
   end
 
   def deliver_with_action_mailer_later
-    DeliverEmailMessageJob.perform_later(self)
+    DeliverEmailMessageJob.perform_later(raw_message: self.to_s, envelope_attributes: envelope_attributes)
   end
 
   def import_delivery_method_from_actionmailer
@@ -142,6 +142,11 @@ module YourPlatformMailMessageExtensions
       delivery_method Mail::Sendmail, location: '/usr/sbin/sendmail', arguments: '-i -t'
     end
   end
+
+  def envelope_attributes
+    {smtp_envelope_to: smtp_envelope_to, smtp_envelope_from: smtp_envelope_from}
+  end
+
 
   # Replace a string in the message, e.g. a {{placeholder}}.
   #

--- a/core_ext/mail/message.rb
+++ b/core_ext/mail/message.rb
@@ -26,9 +26,6 @@ module YourPlatformMailMessageExtensions
       return false unless @allow_recipients_without_account || recipient_is_system_address? || recipient_has_user_account?
     end
 
-    check_anti_spam_criteria_for_address_field :from
-    check_anti_spam_criteria_for_address_field :to
-
     if recipient_address.include?('@')
       begin
         Rails.logger.info "Sending mail smtp_envelope_to #{self.smtp_envelope_to.to_s}."
@@ -51,14 +48,6 @@ module YourPlatformMailMessageExtensions
       Rails.logger.info "Recipient address #{recipient_address} needs review. Not delivering."
       recipient_address_needs_review!
       return false
-    end
-  end
-
-  def check_anti_spam_criteria_for_address_field(field_name)
-    self[field_name].try(:value).to_s.split(",").each do |address_string|
-      unless address_string.include?('"') and address_string.include?('<') and address_string.include?('@')
-        raise 'Make sure the ' + field_name.to_s + ' field (currently ' + address_string + ') is formatted like "Foo" <bar@example.com>. Otherwise this message will be classified as spam by some servers.'
-      end
     end
   end
 

--- a/core_ext/mail/message.rb
+++ b/core_ext/mail/message.rb
@@ -127,7 +127,7 @@ module YourPlatformMailMessageExtensions
   end
 
   def deliver_with_action_mailer_later
-    DeliverMessageJob.perform_later(self)
+    DeliverEmailMessageJob.perform_later(self)
   end
 
   def import_delivery_method_from_actionmailer

--- a/core_ext/mail/message.rb
+++ b/core_ext/mail/message.rb
@@ -126,6 +126,10 @@ module YourPlatformMailMessageExtensions
     deliver
   end
 
+  def deliver_with_action_mailer_later
+    DeliverMessageJob.perform_later(self)
+  end
+
   def import_delivery_method_from_actionmailer
     case ActionMailer::Base.delivery_method
     when :test

--- a/spec/core_ext/mail/message_spec.rb
+++ b/spec/core_ext/mail/message_spec.rb
@@ -28,51 +28,5 @@ describe Mail::Message do
       end
     end
 
-    describe "(spam-protection conformity)" do
-      # https://trello.com/c/s94OXzul, https://stackoverflow.com/q/57173606/2066546
-
-      describe "when the from field has the form 'foo@example.com'" do
-        subject { Mail::Message.new(from: "foo@example.com", to: "\"Bar\" <bar@example.com>", subject: "Test", body: "Test").deliver }
-        it "should raise an error to ensure anti-spam conformity." do
-          expect { subject }.to raise_error(/Make sure the from field .*/)
-        end
-      end
-
-      describe "when the from field has the correct form" do
-        subject { Mail::Message.new(from: "\"Foo\" <foo@example.com>", to: "\"Bar\" <bar@example.com>", subject: "Test", body: "Test").deliver }
-        it "should not raise an error to ensure anti-spam conformity." do
-          expect { subject }.not_to raise_error(/Make sure the from field .*/)
-        end
-      end
-
-      describe "when the to field has the form 'bar@example.com'" do
-        subject { Mail::Message.new(from: "\"Foo\" <foo@example.com>", to: "bar@example.com", subject: "Test", body: "Test").deliver }
-        it "should raise an error to ensure anti-spam conformity." do
-          expect { subject }.to raise_error(/Make sure the to field .*/)
-        end
-      end
-
-      describe "when the to field has the correct form" do
-        subject { Mail::Message.new(from: "\"Foo\" <foo@example.com>", to: "\"Bar\" <bar@example.com>", subject: "Test", body: "Test").deliver }
-        it "should not raise an error to ensure anti-spam conformity." do
-          expect { subject }.not_to raise_error(/Make sure the to field .*/)
-        end
-      end
-
-      describe "when the to field has several recipients in the correct form" do
-        subject { Mail::Message.new(from: "\"Foo\" <foo@example.com>", to: "\"Bar\" <bar@example.com>, \"Baz\" <baz@example.com>", subject: "Test", body: "Test").deliver }
-        it "should not raise an error to ensure anti-spam conformity." do
-          expect { subject }.not_to raise_error(/Make sure the to field .*/)
-        end
-      end
-
-      describe "when the tol field has several recipients, but one in the wrong form" do
-        subject { Mail::Message.new(from: "\"Foo\" <foo@example.com>", to: "\"Bar\" <bar@example.com>, baz@example.com", subject: "Test", body: "Test").deliver }
-        it "should raise an error to ensure anti-spam conformity." do
-          expect { subject }.to raise_error(/Make sure the to field .*/)
-        end
-      end
-
-    end
   end
 end


### PR DESCRIPTION
Dieser Pull-Request baut auf den Fixes von Falk auf (#50).

Wenn wir die Verteiler wieder in Betrieb nehmen, können wir sie noch ein bisschen verbessern:

1. Der E-Mail-Versand wird in Background-Jobs ausgelagert, sodass wir bei E-Mail-Verteilern mit vielen Empfängern keinen Timeout bekommen. (Vorher wurde der komplette Versand innerhalb eines Requests erledigt.)
2. Das Requirement für Absender- und Empfänger-Format

       "John Doe" <john@example.com>

   streiche ich. Das erleichtert die Serialisierung, da dieses Format (mit den Anführungszeichen) durch `message = Message.new(message.to_s)` (Serialisierung) nicht erhalten sein muss.

   Das war ursprünglich mal dafür gedacht, dass unsere E-Mails nicht im Spam-Filter hängen bleiben. Die Anpassung der MX-Records ist aber wahrscheinlich die wirkungsvollere Maßnahme.

3. Delivery-Errors werden per `return_path`-Header an eine separate Adresse geschickt. Auf diese Weise können wir sie (später) nutzen, um Adressen automatisch als ungültig zu markieren, wenn zu viele E-Mails an diese Adresse unzustellbar sind.

Trello: https://trello.com/c/Kia2gaaL/1468-mail-verteiler-wieder-in-betrieb-nehmen